### PR TITLE
Add floating LinkedIn panel and tab-scoped repost tracking

### DIFF
--- a/CODEX_PROJECT.md
+++ b/CODEX_PROJECT.md
@@ -85,6 +85,7 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
 - The main extraction contract for each item is:
   - `link`
   - `author`
+  - `reposted_by`
   - `post_text`
   - `is_repost`
   - `type`

--- a/DELIVERY_CHECKLIST.md
+++ b/DELIVERY_CHECKLIST.md
@@ -11,6 +11,7 @@ Use this checklist before saying a task is done, before committing, and before o
 - Any new permission, host permission, or browser surface was reviewed for necessity.
 - If the change touches extraction logic, promoted posts, polls, and suggested-content exclusions were considered explicitly.
 - If the change touches UI, the popup start action, real-time counter, and export action still match the documented MVP.
+- A Windows system notification was sent with the message `Codex: Tarea completada`.
 
 ## Before Commit
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Chrome/Brave extension project for harvesting raw LinkedIn feed posts, filtering
 - UI: popup with start button, live counter, and export action
 - Product mode: local collection and local export only
 
-This repo is intentionally documented as a browser extension, not as a backend worker. The current phase focuses on LinkedIn home-feed collection, noise filtering, human-like scrolling, `chrome.storage.local` state, and final export. It does not send emails, post comments, or sync to external APIs.
+This repo is intentionally documented as a browser extension, not as a backend worker. The current phase focuses on LinkedIn home-feed collection, noise filtering, human-like scrolling, tab-scoped collection state, and final export. It does not send emails, post comments, or sync to external APIs.
+
+Collected post batches are scoped to the current browser tab/session. Persistent local storage is reserved for lightweight UI preferences such as the floating panel position.
 
 ## MVP Behavior
 
-- Extract `author`, `post_text`, `link`, `is_repost`, `type`, and `extracted_at` from eligible feed posts
+- Extract `author`, `reposted_by`, `post_text`, `link`, `is_repost`, `type`, and `extracted_at` from eligible feed posts
 - Skip promoted posts, polls, and suggested content
 - Scroll in randomized increments between `400px` and `600px`
 - Wait randomized delays between `1.5s` and `3.5s`

--- a/REPO_WORK_RULES.md
+++ b/REPO_WORK_RULES.md
@@ -72,7 +72,7 @@ Recommended local order before commit:
 
 ## Storage And Messaging Rules
 
-- Persist only the minimum local state required for in-progress collection, popup status, and final export.
+- Persist only the minimum local state required for the active tab/session collection flow, and reserve durable local storage for lightweight UI preferences.
 - Keep a documented message contract between content scripts, background, and optional UI surfaces.
 - Do not couple storage shape to raw DOM fragments when a normalized intermediate structure can be stored instead.
 - Make it easy to clear or regenerate local run data during development and debugging.
@@ -84,6 +84,7 @@ Recommended local order before commit:
 - Each exported item should preserve the normalized MVP contract:
   - `link`
   - `author`
+  - `reposted_by`
   - `post_text`
   - `is_repost`
   - `type`
@@ -97,6 +98,10 @@ Recommended local order before commit:
 - Update affected diagram docs in the same PR when permissions, message flow, context boundaries, or collection behavior changes.
 - Keep `README.md` lightweight and use it as a navigation hub to deeper docs.
 - Keep material decisions in `DECISIONS.md` when they affect behavior, permissions, or contract stability.
+
+## Completion Notification Rule
+
+- When a task is completed, send a Windows system notification with the exact message `Codex: Tarea completada`.
 
 ## Repo Conventions Worth Preserving
 

--- a/REQS.MD
+++ b/REQS.MD
@@ -13,6 +13,7 @@ Develop a Chrome Extension (Manifest V3) to automate the collection of raw data 
 ### A. Data Extraction (Content Script)
 Identify and extract the following fields from each post container:
 - `author_name`: Name of the author or the person reposting.
+- `reposted_by`: Name of the reposter when LinkedIn explicitly marks the post as a repost.
 - `post_text`: Full textual content of the post.
 - `link`: link to post.
 - `is_repost`: Boolean flag indicating shared content.
@@ -41,6 +42,7 @@ To load dynamic content and mimic human browsing:
   {
     "link": "urn:li:activity:123456789",
     "author": "Author Name",
+    "reposted_by": "Reposter Name",
     "post_text": "Full post text...",
     "is_repot": false,
     "type": "organic",

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
       <h1>Current Batch</h1>
       <p id="status" class="status">Looking for the LinkedIn feed...</p>
       <p id="count" class="count">Posts identified: 0 / live</p>
+      <p id="repost-count" class="status">Reposts identified: 0</p>
       <button id="export-button" type="button">Export JSON</button>
       <p id="export-feedback" class="feedback" aria-live="polite"></p>
     </div>

--- a/public/linkedin-content.js
+++ b/public/linkedin-content.js
@@ -4,30 +4,55 @@
   const POST_SELECTOR = 'div[role="listitem"]';
   const PROMOTED_LABELS = ["Promoted", "Publicidad"];
   const RELATIONSHIP_MARKERS = ["1st", "2nd", "3rd+", "Following"];
+  const PANEL_ROOT_ID = "linkedin-intelligence-harvester-root";
+  const DEFAULT_PANEL_POSITION = { top: 96, right: 24 };
 
   const MESSAGE_TYPES = {
     feedReady: "collector/feed-ready",
     newItems: "collector/new-items",
+    countUpdated: "collector/count-updated",
+    getState: "collector/get-state",
+    exportRequest: "collector/export-request",
   };
 
   const STATUS_TEXT = {
+    idle: "Waiting for LinkedIn feed...",
     attached: "Collector attached to LinkedIn feed.",
+    scanning: "Collector attached and scanning new posts.",
     unavailable: "LinkedIn feed container not found on this view.",
   };
 
   const STORAGE_KEYS = {
-    status: "collector.status",
+    panelPosition: "collector.panel.position",
+    panelMinimized: "collector.panel.minimized",
   };
 
   const processedElements = new WeakSet();
+  const uiState = {
+    count: 0,
+    repostCount: 0,
+    status: STATUS_TEXT.idle,
+    panelPosition: { ...DEFAULT_PANEL_POSITION },
+    panelMinimized: false,
+    feedVisible: false,
+  };
+
   let feedObserver = null;
   let rootObserver = null;
   let pendingScan = false;
+  let panel = null;
+  let dragState = null;
 
-  bootstrapCollector();
+  void bootstrapCollector();
 
-  function bootstrapCollector() {
+  async function bootstrapCollector() {
+    await hydrateUiState();
+    mountPanel();
     attachToFeedIfPresent();
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+    chrome.runtime.onMessage.addListener(handleRuntimeMessage);
+    window.addEventListener("resize", handleViewportResize);
 
     rootObserver = new MutationObserver(function () {
       attachToFeedIfPresent();
@@ -41,12 +66,90 @@
     }
   }
 
+  async function hydrateUiState() {
+    const [stored, response] = await Promise.all([
+      chrome.storage.local.get([
+        STORAGE_KEYS.panelPosition,
+        STORAGE_KEYS.panelMinimized,
+      ]),
+      chrome.runtime.sendMessage({
+        type: MESSAGE_TYPES.getState,
+      }),
+    ]);
+
+    uiState.count = response?.state?.count || 0;
+    uiState.repostCount = response?.state?.repostCount || 0;
+    uiState.status = response?.state?.status || STATUS_TEXT.idle;
+    uiState.panelPosition = clampPanelPosition(
+      stored[STORAGE_KEYS.panelPosition] || DEFAULT_PANEL_POSITION,
+      { minimized: stored[STORAGE_KEYS.panelMinimized] || false },
+    );
+    uiState.panelMinimized = Boolean(stored[STORAGE_KEYS.panelMinimized]);
+  }
+
+  function handleStorageChange(changes, areaName) {
+    if (areaName !== "local") {
+      return;
+    }
+
+    if (changes[STORAGE_KEYS.panelPosition]) {
+      uiState.panelPosition = clampPanelPosition(
+        changes[STORAGE_KEYS.panelPosition].newValue || DEFAULT_PANEL_POSITION,
+        { minimized: uiState.panelMinimized },
+      );
+    }
+
+    if (changes[STORAGE_KEYS.panelMinimized]) {
+      uiState.panelMinimized = Boolean(
+        changes[STORAGE_KEYS.panelMinimized].newValue,
+      );
+    }
+
+    renderPanel();
+  }
+
+  function handleRuntimeMessage(message) {
+    if (message?.type !== MESSAGE_TYPES.countUpdated) {
+      return;
+    }
+
+    uiState.count = message.count || 0;
+    uiState.repostCount = message.repostCount || 0;
+    uiState.status = message.status || STATUS_TEXT.idle;
+    renderPanel();
+  }
+
+  function handleViewportResize() {
+    uiState.panelPosition = clampPanelPosition(uiState.panelPosition, {
+      minimized: uiState.panelMinimized,
+    });
+    applyPanelPosition();
+    void persistPanelPreferences();
+  }
+
   function normalizeWhitespace(value) {
     return value.replace(/\s+/g, " ").trim();
   }
 
   function escapeRegExp(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function cleanPersonLabel(text) {
+    if (!text) {
+      return null;
+    }
+
+    let cleaned = normalizeWhitespace(text);
+    cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
+    cleaned = cleaned.replace(/\bPremium\b/gi, " ");
+    cleaned = cleaned.replace(/\bProfile\b\s*$/gi, " ");
+    cleaned = cleaned.replace(/[•·]+/g, " ");
+    cleaned = cleaned.replace(/â€¢|Â·/g, " ");
+    cleaned = cleaned.replace(/\s+[•·]+\s*$/g, " ");
+    cleaned = normalizeWhitespace(cleaned);
+
+    return cleaned || null;
   }
 
   function findFeedContainer(root) {
@@ -111,12 +214,7 @@
       return null;
     }
 
-    cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
-    cleaned = cleaned.replace(/\bPremium\b/gi, " ");
-    cleaned = cleaned.replace(/[•·-]+/g, " ");
-    cleaned = normalizeWhitespace(cleaned);
-
-    return cleaned || null;
+    return cleanPersonLabel(cleaned);
   }
 
   function extractAuthor(postElement) {
@@ -142,6 +240,36 @@
     return null;
   }
 
+  function extractRepostMetadata(postElement) {
+    const paragraphs = Array.from(postElement.querySelectorAll("p"));
+
+    for (const paragraph of paragraphs) {
+      const text = normalizeWhitespace(paragraph.textContent || "");
+      const repostMatch = text.match(/^(.*?)\s+reposted this$/i);
+
+      if (repostMatch) {
+        return {
+          is_repost: true,
+          reposted_by: cleanPersonLabel(repostMatch[1]),
+        };
+      }
+
+      if (
+        /^(.*?)\s+(loves this|supports this|found this insightful)$/i.test(text)
+      ) {
+        return {
+          is_repost: false,
+          reposted_by: null,
+        };
+      }
+    }
+
+    return {
+      is_repost: false,
+      reposted_by: null,
+    };
+  }
+
   function buildFingerprint(postElement, author) {
     const visibleText = normalizeWhitespace(postElement.textContent || "").slice(
       0,
@@ -151,12 +279,13 @@
     return author.toLowerCase() + "::" + visibleText.toLowerCase();
   }
 
-  function buildNormalizedItem(postElement, author, now) {
+  function buildNormalizedItem(postElement, author, repostMetadata, now) {
     return {
       link: null,
       author: author,
+      reposted_by: repostMetadata.reposted_by,
       post_text: null,
-      is_repost: null,
+      is_repost: repostMetadata.is_repost,
       type: "organic",
       extracted_at: now.toISOString(),
       fingerprint: buildFingerprint(postElement, author),
@@ -186,7 +315,11 @@
         continue;
       }
 
-      acceptedItems.push(buildNormalizedItem(postElement, author, new Date()));
+      const repostMetadata = extractRepostMetadata(postElement);
+
+      acceptedItems.push(
+        buildNormalizedItem(postElement, author, repostMetadata, new Date()),
+      );
     }
 
     return { acceptedItems: acceptedItems, skippedItems: skippedItems };
@@ -196,6 +329,9 @@
     const feedContainer = findFeedContainer(document);
 
     if (!feedContainer) {
+      uiState.feedVisible = false;
+      uiState.status = STATUS_TEXT.unavailable;
+      renderPanel();
       console.log("[harvester] feed container not found yet");
       chrome.runtime.sendMessage({
         type: MESSAGE_TYPES.feedReady,
@@ -206,6 +342,9 @@
       });
       return;
     }
+
+    uiState.feedVisible = true;
+    renderPanel();
 
     if (feedObserver && feedObserver.feedContainer === feedContainer) {
       return;
@@ -282,5 +421,358 @@
       type: MESSAGE_TYPES.newItems,
       items: scanResult.acceptedItems,
     });
+  }
+
+  function mountPanel() {
+    if (panel) {
+      renderPanel();
+      return panel;
+    }
+
+    const host = document.createElement("div");
+    host.id = PANEL_ROOT_ID;
+    host.style.position = "fixed";
+    host.style.top = "0";
+    host.style.right = "0";
+    host.style.zIndex = "2147483645";
+    host.style.pointerEvents = "none";
+
+    const shadowRoot = host.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `
+      <style>
+        :host {
+          all: initial;
+        }
+
+        .harvester-shell {
+          position: fixed;
+          display: grid;
+          gap: 0;
+          width: 320px;
+          background: #f3efe6;
+          color: #18222d;
+          border: 1px solid rgba(24, 34, 45, 0.12);
+          border-radius: 18px;
+          box-shadow: 0 18px 40px rgba(24, 34, 45, 0.22);
+          overflow: hidden;
+          pointer-events: auto;
+          font-family: "Segoe UI", sans-serif;
+        }
+
+        .harvester-shell[data-state="minimized"] {
+          width: 164px;
+          border-radius: 999px;
+        }
+
+        .harvester-header {
+          display: flex;
+          align-items: flex-start;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 14px 16px 12px;
+          background: linear-gradient(135deg, #fff8ee 0%, #f3efe6 100%);
+          cursor: grab;
+          user-select: none;
+        }
+
+        .harvester-header:active {
+          cursor: grabbing;
+        }
+
+        .harvester-eyebrow {
+          margin: 0 0 6px;
+          color: #7c4f22;
+          font-size: 11px;
+          font-weight: 800;
+          letter-spacing: 0.08em;
+          text-transform: uppercase;
+        }
+
+        .harvester-title {
+          margin: 0;
+          font-size: 20px;
+          line-height: 1.1;
+          font-weight: 800;
+        }
+
+        .harvester-minimize {
+          border: 0;
+          border-radius: 999px;
+          min-width: 34px;
+          height: 34px;
+          background: rgba(10, 102, 194, 0.12);
+          color: #0a66c2;
+          font-size: 20px;
+          line-height: 1;
+          font-weight: 700;
+          cursor: pointer;
+        }
+
+        .harvester-body {
+          display: grid;
+          gap: 12px;
+          padding: 0 16px 16px;
+        }
+
+        .harvester-status,
+        .harvester-count,
+        .harvester-feedback,
+        .harvester-chip {
+          margin: 0;
+          font-size: 14px;
+          line-height: 1.4;
+        }
+
+        .harvester-status {
+          color: #43576b;
+        }
+
+        .harvester-count {
+          font-weight: 800;
+        }
+
+        .harvester-export {
+          border: 0;
+          border-radius: 999px;
+          padding: 12px 14px;
+          background: #0a66c2;
+          color: #ffffff;
+          cursor: pointer;
+          font-size: 14px;
+          font-weight: 800;
+        }
+
+        .harvester-export:disabled {
+          opacity: 0.6;
+          cursor: wait;
+        }
+
+        .harvester-feedback {
+          color: #43576b;
+          min-height: 20px;
+        }
+
+        .harvester-chip {
+          display: none;
+          align-items: center;
+          justify-content: space-between;
+          gap: 8px;
+          width: 100%;
+          border: 0;
+          border-radius: 999px;
+          padding: 14px 16px;
+          background: #0a66c2;
+          color: #ffffff;
+          cursor: pointer;
+          font-size: 13px;
+          font-weight: 800;
+          letter-spacing: 0.02em;
+        }
+
+        .harvester-chip-count {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          min-width: 28px;
+          padding: 2px 8px;
+          border-radius: 999px;
+          background: rgba(255, 255, 255, 0.18);
+        }
+
+        .harvester-shell[data-state="minimized"] .harvester-header,
+        .harvester-shell[data-state="minimized"] .harvester-body {
+          display: none;
+        }
+
+        .harvester-shell[data-state="minimized"] .harvester-chip {
+          display: inline-flex;
+        }
+      </style>
+      <section class="harvester-shell" data-state="expanded">
+        <header class="harvester-header" data-drag-handle="true">
+          <div>
+            <p class="harvester-eyebrow">LinkedIn Intelligence Harvester</p>
+            <h2 class="harvester-title">Current Batch</h2>
+          </div>
+          <button class="harvester-minimize" type="button" aria-label="Minimize panel">-</button>
+        </header>
+        <div class="harvester-body">
+          <p class="harvester-status">Waiting for LinkedIn feed...</p>
+          <p class="harvester-count">Posts identified: 0 / live</p>
+          <p class="harvester-reposts">Reposts identified: 0</p>
+          <button class="harvester-export" type="button">Export JSON</button>
+          <p class="harvester-feedback" aria-live="polite"></p>
+        </div>
+        <button class="harvester-chip" type="button" hidden>
+          Harvester <span class="harvester-chip-count">0</span>
+        </button>
+      </section>
+    `;
+
+    document.documentElement.appendChild(host);
+
+    panel = {
+      host: host,
+      shadowRoot: shadowRoot,
+      shell: shadowRoot.querySelector(".harvester-shell"),
+      header: shadowRoot.querySelector(".harvester-header"),
+      minimizeButton: shadowRoot.querySelector(".harvester-minimize"),
+      status: shadowRoot.querySelector(".harvester-status"),
+      count: shadowRoot.querySelector(".harvester-count"),
+      reposts: shadowRoot.querySelector(".harvester-reposts"),
+      exportButton: shadowRoot.querySelector(".harvester-export"),
+      feedback: shadowRoot.querySelector(".harvester-feedback"),
+      chip: shadowRoot.querySelector(".harvester-chip"),
+      chipCount: shadowRoot.querySelector(".harvester-chip-count"),
+    };
+
+    panel.header.addEventListener("mousedown", handleDragStart);
+    panel.minimizeButton.addEventListener("click", function (event) {
+      event.stopPropagation();
+      void setPanelMinimized(true);
+    });
+    panel.chip.addEventListener("click", function () {
+      void setPanelMinimized(false);
+    });
+    panel.exportButton.addEventListener("click", function () {
+      void exportCurrentBatch();
+    });
+
+    renderPanel();
+    return panel;
+  }
+
+  function renderPanel() {
+    if (!panel) {
+      return;
+    }
+
+    panel.host.style.display = uiState.feedVisible ? "block" : "none";
+    panel.shell.dataset.state = uiState.panelMinimized ? "minimized" : "expanded";
+    panel.status.textContent = uiState.status;
+    panel.count.textContent = "Posts identified: " + uiState.count + " / live";
+    panel.reposts.textContent =
+      "Reposts identified: " + uiState.repostCount;
+    panel.chipCount.textContent = String(uiState.count);
+    panel.chip.hidden = !uiState.panelMinimized;
+    applyPanelPosition();
+  }
+
+  function applyPanelPosition() {
+    if (!panel) {
+      return;
+    }
+
+    panel.shell.style.top = uiState.panelPosition.top + "px";
+    panel.shell.style.right = uiState.panelPosition.right + "px";
+    panel.shell.style.width = uiState.panelMinimized ? "164px" : "320px";
+  }
+
+  async function exportCurrentBatch() {
+    if (!panel) {
+      return;
+    }
+
+    panel.exportButton.disabled = true;
+    panel.feedback.textContent = "Preparing JSON export...";
+
+    try {
+      const response = await chrome.runtime.sendMessage({
+        type: MESSAGE_TYPES.exportRequest,
+      });
+
+      if (!response?.ok) {
+        throw new Error(response?.error || "Export failed");
+      }
+
+      panel.feedback.textContent = "Downloaded " + response.filename;
+    } catch (error) {
+      panel.feedback.textContent = error.message;
+    } finally {
+      panel.exportButton.disabled = false;
+    }
+  }
+
+  function handleDragStart(event) {
+    if (!panel || uiState.panelMinimized) {
+      return;
+    }
+
+    if (event.target.closest("button")) {
+      return;
+    }
+
+    dragState = {
+      startX: event.clientX,
+      startY: event.clientY,
+      startTop: uiState.panelPosition.top,
+      startRight: uiState.panelPosition.right,
+    };
+
+    window.addEventListener("mousemove", handleDragMove);
+    window.addEventListener("mouseup", handleDragEnd);
+  }
+
+  function handleDragMove(event) {
+    if (!dragState) {
+      return;
+    }
+
+    const deltaX = event.clientX - dragState.startX;
+    const deltaY = event.clientY - dragState.startY;
+
+    uiState.panelPosition = clampPanelPosition(
+      {
+        top: dragState.startTop + deltaY,
+        right: dragState.startRight - deltaX,
+      },
+      { minimized: false },
+    );
+
+    applyPanelPosition();
+  }
+
+  function handleDragEnd() {
+    if (!dragState) {
+      return;
+    }
+
+    dragState = null;
+    window.removeEventListener("mousemove", handleDragMove);
+    window.removeEventListener("mouseup", handleDragEnd);
+    void persistPanelPreferences();
+  }
+
+  async function setPanelMinimized(nextValue) {
+    uiState.panelMinimized = nextValue;
+    uiState.panelPosition = clampPanelPosition(uiState.panelPosition, {
+      minimized: nextValue,
+    });
+    renderPanel();
+    await persistPanelPreferences();
+  }
+
+  async function persistPanelPreferences() {
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.panelPosition]: uiState.panelPosition,
+      [STORAGE_KEYS.panelMinimized]: uiState.panelMinimized,
+    });
+  }
+
+  function clampPanelPosition(position, options) {
+    const isMinimized = Boolean(options?.minimized);
+    const width = isMinimized ? 164 : 320;
+    const height = isMinimized ? 52 : 196;
+    const maxRight = Math.max(12, window.innerWidth - width - 12);
+    const maxTop = Math.max(12, window.innerHeight - height - 12);
+
+    return {
+      top: Math.min(Math.max(12, numberOr(position?.top, 96)), maxTop),
+      right: Math.min(Math.max(12, numberOr(position?.right, 24)), maxRight),
+    };
+  }
+
+  function numberOr(value, fallback) {
+    return Number.isFinite(value) ? value : fallback;
   }
 })();

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,28 +1,27 @@
 import { MESSAGE_TYPES, STATUS_TEXT, STORAGE_KEYS } from "../shared/constants.js";
 import {
+  clearTabState,
+  ensureHydratedState,
   getSerializableState,
-  hydrateStateFromStorage,
   markStatus,
   mergeNewItems,
   persistState,
 } from "../shared/state.js";
 
-const hydrationReady = hydrateStateFromStorage().catch((error) => {
-  console.error("[harvester] failed to hydrate state", error);
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void clearTabState(tabId);
 });
 
-chrome.runtime.onInstalled.addListener(async () => {
-  await hydrateStateFromStorage();
-  await persistState();
+chrome.runtime.onInstalled.addListener(() => {
+  void clearLegacyLocalState();
 });
 
-chrome.runtime.onStartup.addListener(async () => {
-  await hydrateStateFromStorage();
-  await persistState();
+chrome.runtime.onStartup.addListener(() => {
+  void clearLegacyLocalState();
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  void handleMessage(message)
+  void handleMessage(message, _sender)
     .then((response) => sendResponse(response))
     .catch((error) => {
       console.error("[harvester] background error", error);
@@ -32,16 +31,29 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return true;
 });
 
-async function handleMessage(message) {
-  await hydrationReady;
+async function handleMessage(message, sender) {
+  const tabId = resolveTabId(message, sender);
+
+  if (tabId == null && message?.type !== MESSAGE_TYPES.exportRequest) {
+    return { ok: false, error: "tabId is required" };
+  }
+
+  if (tabId != null) {
+    await ensureHydratedState(tabId);
+  }
 
   switch (message?.type) {
+    case MESSAGE_TYPES.getState: {
+      const state = getSerializableState(tabId);
+      return { ok: true, state, tabId };
+    }
+
     case MESSAGE_TYPES.feedReady: {
       const status = message.feedFound
         ? STATUS_TEXT.attached
         : STATUS_TEXT.unavailable;
-      const state = await markStatus(status);
-      await broadcastCountUpdated(state);
+      const state = await markStatus(tabId, status);
+      await broadcastCountUpdated(tabId, state);
       return { ok: true, state };
     }
 
@@ -50,15 +62,19 @@ async function handleMessage(message) {
         return { ok: false, error: "items must be an array" };
       }
 
-      await markStatus(STATUS_TEXT.scanning);
-      const mergeResult = mergeNewItems(message.items);
-      const state = await persistState();
-      await broadcastCountUpdated(state);
+      await markStatus(tabId, STATUS_TEXT.scanning);
+      const mergeResult = mergeNewItems(tabId, message.items);
+      const state = await persistState(tabId);
+      await broadcastCountUpdated(tabId, state);
       return { ok: true, addedCount: mergeResult.addedCount, state };
     }
 
     case MESSAGE_TYPES.exportRequest: {
-      const state = getSerializableState();
+      if (tabId == null) {
+        return { ok: false, error: "tabId is required for export" };
+      }
+
+      const state = getSerializableState(tabId);
       const filename = buildExportFilename();
       const json = JSON.stringify(state.items, null, 2);
       const dataUrl = `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
@@ -88,18 +104,52 @@ async function handleMessage(message) {
   }
 }
 
-async function broadcastCountUpdated(state) {
+async function broadcastCountUpdated(tabId, state) {
   try {
     await chrome.runtime.sendMessage({
       type: MESSAGE_TYPES.countUpdated,
+      tabId,
       count: state.count,
+      repostCount: state.repostCount,
       status: state.status,
     });
   } catch {
     // Popup listeners are optional and often disconnected.
   }
+
+  try {
+    await chrome.tabs.sendMessage(tabId, {
+      type: MESSAGE_TYPES.countUpdated,
+      tabId,
+      count: state.count,
+      repostCount: state.repostCount,
+      status: state.status,
+    });
+  } catch {
+    // Content scripts are optional for non-LinkedIn tabs.
+  }
 }
 
 function buildExportFilename(date = new Date()) {
   return `linkedin_dump_${date.toISOString().slice(0, 10)}.json`;
+}
+
+function resolveTabId(message, sender) {
+  if (Number.isInteger(message?.tabId)) {
+    return message.tabId;
+  }
+
+  if (Number.isInteger(sender?.tab?.id)) {
+    return sender.tab.id;
+  }
+
+  return null;
+}
+
+async function clearLegacyLocalState() {
+  await chrome.storage.local.remove([
+    STORAGE_KEYS.items,
+    STORAGE_KEYS.count,
+    STORAGE_KEYS.status,
+  ]);
 }

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -9,12 +9,15 @@ export const STORAGE_KEYS = {
   count: "collector.count",
   status: "collector.status",
   lastExportAt: "collector.lastExportAt",
+  panelPosition: "collector.panel.position",
+  panelMinimized: "collector.panel.minimized",
 };
 
 export const MESSAGE_TYPES = {
   feedReady: "collector/feed-ready",
   newItems: "collector/new-items",
   countUpdated: "collector/count-updated",
+  getState: "collector/get-state",
   exportRequest: "collector/export-request",
   exportResult: "collector/export-result",
 };

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -12,6 +12,23 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function cleanPersonLabel(text) {
+  if (!text) {
+    return null;
+  }
+
+  let cleaned = normalizeWhitespace(text);
+  cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
+  cleaned = cleaned.replace(/\bPremium\b/gi, " ");
+  cleaned = cleaned.replace(/\bProfile\b\s*$/gi, " ");
+  cleaned = cleaned.replace(/[•·]+/g, " ");
+  cleaned = cleaned.replace(/â€¢|Â·/g, " ");
+  cleaned = cleaned.replace(/\s+[•·]+\s*$/g, " ");
+  cleaned = normalizeWhitespace(cleaned);
+
+  return cleaned || null;
+}
+
 export function findFeedContainer(root = document) {
   return root.querySelector(FEED_SELECTOR);
 }
@@ -92,12 +109,37 @@ function removeRelationshipMarker(text) {
     return null;
   }
 
-  cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
-  cleaned = cleaned.replace(/\bPremium\b/gi, " ");
-  cleaned = cleaned.replace(/[•·-]+/g, " ");
-  cleaned = normalizeWhitespace(cleaned);
+  return cleanPersonLabel(cleaned);
+}
 
-  return cleaned || null;
+export function extractRepostMetadata(postElement) {
+  const paragraphs = Array.from(postElement.querySelectorAll("p"));
+
+  for (const paragraph of paragraphs) {
+    const text = normalizeWhitespace(paragraph.textContent || "");
+    const repostMatch = text.match(/^(.*?)\s+reposted this$/i);
+
+    if (repostMatch) {
+      return {
+        is_repost: true,
+        reposted_by: cleanPersonLabel(repostMatch[1]),
+      };
+    }
+
+    if (
+      /^(.*?)\s+(loves this|supports this|found this insightful)$/i.test(text)
+    ) {
+      return {
+        is_repost: false,
+        reposted_by: null,
+      };
+    }
+  }
+
+  return {
+    is_repost: false,
+    reposted_by: null,
+  };
 }
 
 export function buildFingerprint(postElement, author) {
@@ -109,12 +151,18 @@ export function buildFingerprint(postElement, author) {
   return `${author.toLowerCase()}::${visibleText.toLowerCase()}`;
 }
 
-export function buildNormalizedItem(postElement, author, now = new Date()) {
+export function buildNormalizedItem(
+  postElement,
+  author,
+  repostMetadata,
+  now = new Date(),
+) {
   return {
     link: null,
     author,
+    reposted_by: repostMetadata.reposted_by,
     post_text: null,
-    is_repost: null,
+    is_repost: repostMetadata.is_repost,
     type: "organic",
     extracted_at: now.toISOString(),
     fingerprint: buildFingerprint(postElement, author),
@@ -132,9 +180,11 @@ export function analyzePostElement(postElement, now = new Date()) {
     return { status: "skipped", reason: "missing-author" };
   }
 
+  const repostMetadata = extractRepostMetadata(postElement);
+
   return {
     status: "accepted",
-    item: buildNormalizedItem(postElement, author, now),
+    item: buildNormalizedItem(postElement, author, repostMetadata, now),
   };
 }
 

--- a/src/shared/panel.js
+++ b/src/shared/panel.js
@@ -1,0 +1,77 @@
+const DEFAULT_POSITION = {
+  top: 96,
+  right: 24,
+};
+
+const PANEL_SIZE = {
+  expandedWidth: 320,
+  expandedHeight: 196,
+  minimizedWidth: 164,
+  minimizedHeight: 52,
+};
+
+function ensureNumber(value, fallback) {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+export function getDefaultPanelPosition() {
+  return { ...DEFAULT_POSITION };
+}
+
+export function clampPanelPosition(
+  position,
+  viewport = {},
+  { minimized = false } = {},
+) {
+  const width = minimized ? PANEL_SIZE.minimizedWidth : PANEL_SIZE.expandedWidth;
+  const height = minimized
+    ? PANEL_SIZE.minimizedHeight
+    : PANEL_SIZE.expandedHeight;
+  const viewportWidth = ensureNumber(viewport.width, 1280);
+  const viewportHeight = ensureNumber(viewport.height, 720);
+  const maxRight = Math.max(12, viewportWidth - width - 12);
+  const maxTop = Math.max(12, viewportHeight - height - 12);
+
+  return {
+    top: Math.min(
+      Math.max(12, ensureNumber(position?.top, DEFAULT_POSITION.top)),
+      maxTop,
+    ),
+    right: Math.min(
+      Math.max(12, ensureNumber(position?.right, DEFAULT_POSITION.right)),
+      maxRight,
+    ),
+  };
+}
+
+export function buildPanelStyles(position, { minimized = false } = {}) {
+  return {
+    top: `${position.top}px`,
+    right: `${position.right}px`,
+    width: minimized ? `${PANEL_SIZE.minimizedWidth}px` : "320px",
+  };
+}
+
+export function createPanelMarkup() {
+  return `
+    <section class="harvester-shell harvester-expanded" data-state="expanded">
+      <header class="harvester-header" data-drag-handle="true">
+        <div>
+          <p class="harvester-eyebrow">LinkedIn Intelligence Harvester</p>
+          <h2 class="harvester-title">Current Batch</h2>
+        </div>
+        <button class="harvester-minimize" type="button" aria-label="Minimize panel">-</button>
+      </header>
+      <div class="harvester-body">
+        <p class="harvester-status">Waiting for LinkedIn feed...</p>
+        <p class="harvester-count">Posts identified: 0 / live</p>
+        <button class="harvester-export" type="button">Export JSON</button>
+        <p class="harvester-feedback" aria-live="polite"></p>
+      </div>
+      <button class="harvester-chip" type="button" hidden>
+        Harvester <span class="harvester-chip-count">0</span>
+      </button>
+    </section>
+  `;
+}
+

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -1,80 +1,24 @@
-import { STATUS_TEXT, STORAGE_KEYS } from "./constants.js";
+import { STATUS_TEXT } from "./constants.js";
 
-const memoryState = {
-  itemsByFingerprint: new Map(),
-  status: STATUS_TEXT.idle,
-};
+const tabStates = new Map();
 
-export function getSerializableState() {
+function createEmptyState() {
   return {
-    items: Array.from(memoryState.itemsByFingerprint.values()).map(
-      ({ fingerprint, ...item }) => item,
-    ),
-    count: memoryState.itemsByFingerprint.size,
-    status: memoryState.status,
+    itemsByFingerprint: new Map(),
+    status: STATUS_TEXT.idle,
   };
 }
 
-export function markStatus(status) {
-  memoryState.status = status;
-  return persistState();
-}
-
-export function mergeNewItems(items) {
-  let addedCount = 0;
-
-  for (const item of items) {
-    if (!item?.fingerprint) {
-      continue;
-    }
-
-    if (memoryState.itemsByFingerprint.has(item.fingerprint)) {
-      continue;
-    }
-
-    memoryState.itemsByFingerprint.set(item.fingerprint, item);
-    addedCount += 1;
+function getOrCreateTabState(tabId) {
+  if (!tabStates.has(tabId)) {
+    tabStates.set(tabId, createEmptyState());
   }
 
-  return {
-    addedCount,
-    state: getSerializableState(),
-  };
+  return tabStates.get(tabId);
 }
 
-export async function persistState() {
-  const serializable = getSerializableState();
-
-  await chrome.storage.local.set({
-    [STORAGE_KEYS.items]: serializable.items,
-    [STORAGE_KEYS.count]: serializable.count,
-    [STORAGE_KEYS.status]: serializable.status,
-  });
-
-  return serializable;
-}
-
-export async function hydrateStateFromStorage() {
-  const stored = await chrome.storage.local.get([
-    STORAGE_KEYS.items,
-    STORAGE_KEYS.status,
-  ]);
-
-  memoryState.itemsByFingerprint.clear();
-
-  for (const item of stored[STORAGE_KEYS.items] || []) {
-    const fingerprint = item?.fingerprint || buildFallbackFingerprint(item);
-
-    if (!fingerprint) {
-      continue;
-    }
-
-    memoryState.itemsByFingerprint.set(fingerprint, { ...item, fingerprint });
-  }
-
-  memoryState.status = stored[STORAGE_KEYS.status] || STATUS_TEXT.idle;
-
-  return getSerializableState();
+function buildTabStorageKey(tabId) {
+  return `collector.tab.${tabId}`;
 }
 
 function buildFallbackFingerprint(item) {
@@ -83,4 +27,91 @@ function buildFallbackFingerprint(item) {
   }
 
   return `${item.author.toLowerCase()}::${item.extracted_at}`;
+}
+
+export function getSerializableState(tabId) {
+  const tabState = getOrCreateTabState(tabId);
+  const items = Array.from(tabState.itemsByFingerprint.values()).map(
+    ({ fingerprint, ...item }) => item,
+  );
+
+  return {
+    items,
+    count: tabState.itemsByFingerprint.size,
+    repostCount: items.filter((item) => item.is_repost).length,
+    status: tabState.status,
+  };
+}
+
+export function markStatus(tabId, status) {
+  const tabState = getOrCreateTabState(tabId);
+  tabState.status = status;
+  return persistState(tabId);
+}
+
+export function mergeNewItems(tabId, items) {
+  const tabState = getOrCreateTabState(tabId);
+  let addedCount = 0;
+
+  for (const item of items) {
+    if (!item?.fingerprint) {
+      continue;
+    }
+
+    if (tabState.itemsByFingerprint.has(item.fingerprint)) {
+      continue;
+    }
+
+    tabState.itemsByFingerprint.set(item.fingerprint, item);
+    addedCount += 1;
+  }
+
+  return {
+    addedCount,
+    state: getSerializableState(tabId),
+  };
+}
+
+export async function persistState(tabId) {
+  const serializable = getSerializableState(tabId);
+
+  await chrome.storage.session.set({
+    [buildTabStorageKey(tabId)]: serializable,
+  });
+
+  return serializable;
+}
+
+export async function hydrateStateFromStorage(tabId) {
+  const stored = await chrome.storage.session.get(buildTabStorageKey(tabId));
+  const storedState = stored[buildTabStorageKey(tabId)];
+  const tabState = createEmptyState();
+
+  for (const item of storedState?.items || []) {
+    const fingerprint = item?.fingerprint || buildFallbackFingerprint(item);
+
+    if (!fingerprint) {
+      continue;
+    }
+
+    tabState.itemsByFingerprint.set(fingerprint, { ...item, fingerprint });
+  }
+
+  tabState.status = storedState?.status || STATUS_TEXT.idle;
+  tabStates.set(tabId, tabState);
+
+  return getSerializableState(tabId);
+}
+
+export async function ensureHydratedState(tabId) {
+  if (tabStates.has(tabId)) {
+    return getSerializableState(tabId);
+  }
+
+  return hydrateStateFromStorage(tabId);
+}
+
+export async function clearTabState(tabId) {
+  tabStates.delete(tabId);
+  await chrome.storage.session.remove(buildTabStorageKey(tabId));
 }

--- a/src/ui/popup/main.js
+++ b/src/ui/popup/main.js
@@ -1,33 +1,26 @@
-import { MESSAGE_TYPES, STORAGE_KEYS } from "../../shared/constants.js";
+import { MESSAGE_TYPES } from "../../shared/constants.js";
 import "./style.css";
 
 const countElement = document.querySelector("#count");
+const repostCountElement = document.querySelector("#repost-count");
 const statusElement = document.querySelector("#status");
 const exportButton = document.querySelector("#export-button");
 const exportFeedback = document.querySelector("#export-feedback");
+let activeTabId = null;
 
 void hydratePopup();
-
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName !== "local") {
-    return;
-  }
-
-  if (changes[STORAGE_KEYS.count]) {
-    renderCount(changes[STORAGE_KEYS.count].newValue || 0);
-  }
-
-  if (changes[STORAGE_KEYS.status]) {
-    renderStatus(changes[STORAGE_KEYS.status].newValue || "Idle");
-  }
-});
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message?.type !== MESSAGE_TYPES.countUpdated) {
     return;
   }
 
+  if (message.tabId !== activeTabId) {
+    return;
+  }
+
   renderCount(message.count || 0);
+  renderRepostCount(message.repostCount || 0);
   renderStatus(message.status || "Idle");
 });
 
@@ -38,6 +31,7 @@ exportButton?.addEventListener("click", async () => {
   try {
     const response = await chrome.runtime.sendMessage({
       type: MESSAGE_TYPES.exportRequest,
+      tabId: activeTabId,
     });
 
     if (!response?.ok) {
@@ -53,17 +47,32 @@ exportButton?.addEventListener("click", async () => {
 });
 
 async function hydratePopup() {
-  const stored = await chrome.storage.local.get([
-    STORAGE_KEYS.count,
-    STORAGE_KEYS.status,
-  ]);
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  activeTabId = tab?.id ?? null;
 
-  renderCount(stored[STORAGE_KEYS.count] || 0);
-  renderStatus(stored[STORAGE_KEYS.status] || "Waiting for LinkedIn feed...");
+  if (activeTabId == null) {
+    renderCount(0);
+    renderStatus("No active browser tab.");
+    exportButton.disabled = true;
+    return;
+  }
+
+  const response = await chrome.runtime.sendMessage({
+    type: MESSAGE_TYPES.getState,
+    tabId: activeTabId,
+  });
+
+  renderCount(response?.state?.count || 0);
+  renderRepostCount(response?.state?.repostCount || 0);
+  renderStatus(response?.state?.status || "Waiting for LinkedIn feed...");
 }
 
 function renderCount(count) {
   countElement.textContent = `Posts identified: ${count} / live`;
+}
+
+function renderRepostCount(repostCount) {
+  repostCountElement.textContent = `Reposts identified: ${repostCount}`;
 }
 
 function renderStatus(status) {

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { JSDOM } from "jsdom";
 import {
   extractAuthor,
+  extractRepostMetadata,
   findFeedContainer,
   findPostElements,
   isPromotedPost,
@@ -17,7 +18,7 @@ const FEED_FIXTURE = `
         <span aria-hidden="true">
           Gonzalo Corbijn
           <span class="verified"></span>
-          <span class="relationship"><span> • 1st</span></span>
+          <span class="relationship"><span> â€¢ 1st</span></span>
         </span>
       </div>
     </div>
@@ -26,7 +27,7 @@ const FEED_FIXTURE = `
         <p>Promoted by Acme</p>
         <span aria-hidden="true">
           Should Be Ignored
-          <span class="relationship"><span> • 2nd</span></span>
+          <span class="relationship"><span> â€¢ 2nd</span></span>
         </span>
       </div>
     </div>
@@ -35,7 +36,7 @@ const FEED_FIXTURE = `
         <p>Another organic post</p>
         <span aria-hidden="true">
           Ada Lovelace
-          <span class="relationship"><span> • 3rd+</span></span>
+          <span class="relationship"><span> â€¢ 3rd+</span></span>
         </span>
       </div>
     </div>
@@ -53,6 +54,27 @@ const FEED_FIXTURE = `
         </span>
       </div>
     </div>
+    <div role="listitem" data-post-id="repost-post">
+      <div>
+        <p>Charity Majors reposted this</p>
+      </div>
+      <div>
+        <span aria-hidden="true">
+          Liz Fong-Jones
+          <span class="relationship"><span> â€¢ 3rd+</span></span>
+        </span>
+      </div>
+    </div>
+    <div role="listitem" data-post-id="support-post">
+      <div>
+        <p>Gabriel Millien supports this</p>
+      </div>
+      <div>
+        <span aria-hidden="true">
+          Cruz Gamboa Premium Profile 3rd+
+        </span>
+      </div>
+    </div>
   </div>
 `;
 
@@ -66,7 +88,7 @@ describe("LinkedIn feed smoke extraction", () => {
     const container = findFeedContainer(document);
 
     expect(container).not.toBeNull();
-    expect(findPostElements(container)).toHaveLength(5);
+    expect(findPostElements(container)).toHaveLength(7);
   });
 
   it("filters promoted content", () => {
@@ -84,6 +106,21 @@ describe("LinkedIn feed smoke extraction", () => {
     expect(extractAuthor(posts[0])).toBe("Gonzalo Corbijn");
     expect(extractAuthor(posts[2])).toBe("Ada Lovelace");
     expect(extractAuthor(posts[4])).toBe("Kelsey Hightower");
+    expect(extractAuthor(posts[6])).toBe("Cruz Gamboa");
+  });
+
+  it("detects repost metadata without misclassifying social suggestions", () => {
+    const document = setupDocument();
+    const posts = findPostElements(findFeedContainer(document));
+
+    expect(extractRepostMetadata(posts[5])).toEqual({
+      is_repost: true,
+      reposted_by: "Charity Majors",
+    });
+    expect(extractRepostMetadata(posts[6])).toEqual({
+      is_repost: false,
+      reposted_by: null,
+    });
   });
 
   it("scans only new elements in repeated rescans", () => {
@@ -97,9 +134,19 @@ describe("LinkedIn feed smoke extraction", () => {
     });
     const secondPass = scanFeedPosts(container, { processedElements });
 
-    expect(firstPass.acceptedItems).toHaveLength(3);
+    expect(firstPass.acceptedItems).toHaveLength(5);
     expect(firstPass.skippedItems).toContain("promoted");
     expect(firstPass.skippedItems).toContain("missing-author");
+    expect(firstPass.acceptedItems[3]).toMatchObject({
+      author: "Liz Fong-Jones",
+      is_repost: true,
+      reposted_by: "Charity Majors",
+    });
+    expect(firstPass.acceptedItems[4]).toMatchObject({
+      author: "Cruz Gamboa",
+      is_repost: false,
+      reposted_by: null,
+    });
     expect(secondPass.acceptedItems).toHaveLength(0);
   });
 
@@ -111,10 +158,10 @@ describe("LinkedIn feed smoke extraction", () => {
       nowFactory: () => new Date("2026-03-16T20:00:00.000Z"),
     });
 
-    const firstMerge = mergeNewItems(acceptedItems);
-    const secondMerge = mergeNewItems(acceptedItems);
+    const firstMerge = mergeNewItems(101, acceptedItems);
+    const secondMerge = mergeNewItems(101, acceptedItems);
 
-    expect(firstMerge.addedCount).toBe(3);
+    expect(firstMerge.addedCount).toBe(5);
     expect(secondMerge.addedCount).toBe(0);
   });
 });

--- a/test/panel.smoke.test.js
+++ b/test/panel.smoke.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPanelStyles,
+  clampPanelPosition,
+  createPanelMarkup,
+  getDefaultPanelPosition,
+} from "../src/shared/panel.js";
+
+describe("floating panel helpers", () => {
+  it("returns a stable default position", () => {
+    expect(getDefaultPanelPosition()).toEqual({ top: 96, right: 24 });
+  });
+
+  it("clamps expanded position into the viewport", () => {
+    expect(
+      clampPanelPosition(
+        { top: -50, right: 5000 },
+        { width: 1200, height: 800 },
+        { minimized: false },
+      ),
+    ).toEqual({ top: 12, right: 868 });
+  });
+
+  it("clamps minimized position using minimized bounds", () => {
+    expect(
+      clampPanelPosition(
+        { top: 999, right: 999 },
+        { width: 600, height: 400 },
+        { minimized: true },
+      ),
+    ).toEqual({ top: 336, right: 424 });
+  });
+
+  it("builds inline styles from a clamped position", () => {
+    expect(
+      buildPanelStyles({ top: 120, right: 48 }, { minimized: false }),
+    ).toEqual({
+      top: "120px",
+      right: "48px",
+      width: "320px",
+    });
+  });
+
+  it("creates markup with minimized chip and controls", () => {
+    const markup = createPanelMarkup();
+
+    expect(markup).toContain("harvester-header");
+    expect(markup).toContain("harvester-export");
+    expect(markup).toContain("harvester-chip");
+  });
+});


### PR DESCRIPTION
## Summary
- add an in-page floating control panel for LinkedIn with drag, minimize, and persisted UI position
- detect repost metadata via eposted_by while keeping the original post author intact
- move collector batch state to tab-scoped session storage and add a repost counter to the UI
- update repo docs and smoke tests to reflect the new behavior

## Testing
- npm test
- npm run build