### PR TITLE
Implement BL-004 permalink capture and resilient AI retries

### DIFF
--- a/backlog.done.md
+++ b/backlog.done.md
@@ -1,0 +1,13 @@
+# Done Backlog
+
+## BL-001: Validacion de relevancia con Gemini AI Studio (API)
+
+Estado: terminado.
+
+Integrar una etapa de validacion posterior al primer filtro del crawler usando la API de Gemini AI Studio, apuntando a un system instruction/Gem ya definido por el equipo.
+Objetivo: decidir si un post ya recolectado realmente nos interesa para comentar bajo nuestro perfil.
+
+### Resultado esperado
+- Cada post que pase el primer filtro debe recibir una decision adicional de interes basada en Gemini.
+- La decision debe quedar registrada junto al post para trazabilidad.
+- El pipeline debe permitir continuar aunque falle la llamada al servicio (fallback controlado).

--- a/backlog.md
+++ b/backlog.md
@@ -1,15 +1,5 @@
 # Backlog
 
-## BL-001: Validacion de relevancia con Gemini AI Studio (API)
-
-Integrar una etapa de validacion posterior al primer filtro del crawler usando la API de Gemini AI Studio, apuntando a un system instruction/Gem ya definido por el equipo.
-Objetivo: decidir si un post ya recolectado realmente nos interesa para comentar bajo nuestro perfil.
-
-### Resultado esperado
-- Cada post que pase el primer filtro debe recibir una decision adicional de interes (`interesa` / `no_interesa`) basada en Gemini.
-- La decision debe quedar registrada junto al post para trazabilidad.
-- El pipeline debe permitir continuar aunque falle la llamada al servicio (fallback controlado).
-
 ## BL-002: Categorizacion de "peso" del autor del post
 
 Agregar clasificacion del autor del post para estimar si es un perfil "peso pesado" o no, usando:

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "LinkedIn Intelligence Harvester",
   "version": "0.1.0",
   "description": "Collects organic LinkedIn posts, extracts authors, and exports the current batch as JSON.",
-  "permissions": ["storage", "activeTab", "downloads", "tabs"],
+  "permissions": ["storage", "activeTab", "downloads", "tabs", "alarms"],
   "host_permissions": [
     "https://www.linkedin.com/*",
     "https://generativelanguage.googleapis.com/*"

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -53,6 +53,7 @@ import {
 
 const activeEnrichments = new Map();
 const validationWorkers = new Map();
+const AI_RETRY_ALARM_PREFIX = "collector.ai.retry.";
 
 chrome.tabs.onRemoved.addListener((tabId) => {
   void clearTabState(tabId);
@@ -64,6 +65,27 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.runtime.onStartup.addListener(() => {
   void clearLegacyLocalState();
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (!alarm?.name?.startsWith(AI_RETRY_ALARM_PREFIX)) {
+    return;
+  }
+
+  const tabId = Number.parseInt(
+    alarm.name.slice(AI_RETRY_ALARM_PREFIX.length),
+    10,
+  );
+
+  if (!Number.isInteger(tabId)) {
+    return;
+  }
+
+  logServiceWorkerEvent("ai-validation-alarm-fired", {
+    tabId,
+    alarm: alarm.name,
+  });
+  void ensureHydratedState(tabId).then(() => ensureValidationWorker(tabId));
 });
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -605,7 +627,8 @@ async function runValidationWorker(tabId) {
         message: normalizedError.message,
       });
       await broadcastCountUpdated(tabId, queueState);
-      await delay(retryDelayMs);
+      await scheduleValidationRetryAlarm(tabId, retryDelayMs);
+      return;
     }
   }
 }
@@ -890,6 +913,22 @@ function normalizeAiError(error) {
   const nextError = new Error(error?.message || "Unexpected AI validation error.");
   nextError.kind = "network-error";
   return nextError;
+}
+
+async function scheduleValidationRetryAlarm(tabId, delayMs) {
+  const alarmName = `${AI_RETRY_ALARM_PREFIX}${tabId}`;
+  const delayMinutes = Math.max(1 / 60, delayMs / 60000);
+
+  await chrome.alarms.create(alarmName, {
+    delayInMinutes: delayMinutes,
+  });
+
+  logServiceWorkerEvent("ai-validation-alarm-scheduled", {
+    tabId,
+    alarmName,
+    delayMs,
+    delayMinutes,
+  });
 }
 
 function delay(ms) {

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -6,6 +6,10 @@
   const SUGGESTED_LABELS = ["Suggested", "Sugerido"];
   const RELATIONSHIP_MARKERS = ["1st", "2nd", "3rd+", "Following"];
   const POSTED_TIME_PATTERN = /^(now|\d+\s*(?:s|m|h|d|w|mo|y))\b/i;
+  const OVERFLOW_BUTTON_SELECTOR =
+    'button[aria-label*="Open control menu for post"]';
+  const FLOATING_MENU_SELECTOR = 'div[popover="manual"] [role="menu"]';
+  const MENU_ITEM_SELECTOR = '[role="menuitem"]';
   const PANEL_ROOT_ID = "linkedin-intelligence-harvester-root";
   const DEFAULT_PANEL_POSITION = { top: 96, right: 24 };
   const TARGET_COUNT_DEFAULT = 50;
@@ -1070,6 +1074,137 @@
     };
   }
 
+  function findPostOverflowButton(postElement) {
+    return postElement?.querySelector(OVERFLOW_BUTTON_SELECTOR) || null;
+  }
+
+  function findFloatingPostMenu() {
+    return document.querySelector(FLOATING_MENU_SELECTOR);
+  }
+
+  function findCopyLinkMenuItem(menuElement) {
+    return (
+      Array.from(menuElement?.querySelectorAll(MENU_ITEM_SELECTOR) || []).find((item) =>
+        normalizeWhitespace(item.textContent || "")
+          .toLowerCase()
+          .includes("copy link to post"),
+      ) || null
+    );
+  }
+
+  async function resolvePostPermalink(postElement, previousLink = null) {
+    const overflowButton = findPostOverflowButton(postElement);
+
+    if (!overflowButton) {
+      logPage("permalink-overflow-button-missing");
+      return null;
+    }
+
+    logPage("permalink-menu-opening");
+    overflowButton.click();
+
+    const menuElement = await waitForElement(findFloatingPostMenu, 1200);
+
+    if (!menuElement) {
+      logPage("permalink-menu-timeout");
+      return null;
+    }
+
+    logPage("permalink-menu-found");
+    const copyLinkItem = findCopyLinkMenuItem(menuElement);
+
+    if (!copyLinkItem) {
+      logPage("permalink-copy-link-item-missing");
+      closeFloatingMenu(overflowButton);
+      return null;
+    }
+
+    logPage("permalink-copy-link-click");
+    copyLinkItem.click();
+    await sleep(200);
+    const clipboardUrl = normalizeCapturedPermalink(
+      await readClipboardPermalink(),
+    );
+    closeFloatingMenu(overflowButton);
+
+    if (clipboardUrl) {
+      if (isDuplicatePermalink(clipboardUrl, previousLink)) {
+        logPage("permalink-duplicate-detected", {
+          candidate: clipboardUrl,
+          previousLink: previousLink,
+        });
+        return null;
+      }
+
+      logPage("permalink-found-in-clipboard", { link: clipboardUrl });
+      return clipboardUrl;
+    }
+
+    logPage("permalink-resolution-failed");
+    return null;
+  }
+
+  async function readClipboardPermalink() {
+    if (!navigator.clipboard?.readText) {
+      logPage("permalink-clipboard-unavailable");
+      return null;
+    }
+
+    await sleep(150);
+
+    try {
+      const text = (await navigator.clipboard.readText()).trim();
+      return text;
+    } catch (error) {
+      logPage("permalink-clipboard-read-failed", { message: error.message });
+    }
+
+    return null;
+  }
+
+  function closeFloatingMenu(overflowButton) {
+    overflowButton?.click();
+  }
+
+  function normalizeCapturedPermalink(value) {
+    const normalized = String(value || "").trim();
+
+    if (!normalized) {
+      return null;
+    }
+
+    if (!/^https:\/\/www\.linkedin\.com\//i.test(normalized)) {
+      return null;
+    }
+
+    return normalized;
+  }
+
+  function isDuplicatePermalink(candidate, previousLink) {
+    return Boolean(candidate && previousLink && candidate === previousLink);
+  }
+
+  async function waitForElement(getElement, timeoutMs) {
+    const existing = getElement();
+
+    if (existing) {
+      return existing;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      await sleep(50);
+      const element = getElement();
+
+      if (element) {
+        return element;
+      }
+    }
+
+    return null;
+  }
+
   function extractProfileSignals() {
     const roleSelectors = [
       ".text-body-medium.break-words",
@@ -1106,9 +1241,10 @@
     };
   }
 
-  function scanFeedPosts(feedContainer) {
+  async function scanFeedPosts(feedContainer) {
     const acceptedItems = [];
     const skippedItems = [];
+    let previousAcceptedLink = null;
 
     for (const postElement of findPostElements(feedContainer)) {
       const currentElementSignature = normalizeWhitespace(
@@ -1140,9 +1276,17 @@
 
       const repostMetadata = extractRepostMetadata(postElement);
 
-      acceptedItems.push(
-        buildNormalizedItem(postElement, author, repostMetadata, new Date()),
+      const item = buildNormalizedItem(
+        postElement,
+        author,
+        repostMetadata,
+        new Date(),
       );
+      item.link = await resolvePostPermalink(postElement, previousAcceptedLink);
+      if (item.link) {
+        previousAcceptedLink = item.link;
+      }
+      acceptedItems.push(item);
     }
 
     return { acceptedItems: acceptedItems, skippedItems: skippedItems };
@@ -1200,7 +1344,7 @@
 
   async function runScan(feedContainer) {
     const totalListItems = findPostElements(feedContainer).length;
-    const scanResult = scanFeedPosts(feedContainer);
+    const scanResult = await scanFeedPosts(feedContainer);
     const skippedBreakdown = summarizeSkippedReasons(scanResult.skippedItems);
 
     logPage("scan complete", {

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -5,6 +5,10 @@ const PROMOTED_LABELS = ["Promoted", "Publicidad"];
 const SUGGESTED_LABELS = ["Suggested", "Sugerido"];
 const RELATIONSHIP_MARKERS = ["1st", "2nd", "3rd+", "Following"];
 const POSTED_TIME_PATTERN = /^(now|\d+\s*(?:s|m|h|d|w|mo|y))\b/i;
+const OVERFLOW_BUTTON_SELECTOR =
+  'button[aria-label*="Open control menu for post"]';
+const FLOATING_MENU_SELECTOR = 'div[popover="manual"] [role="menu"]';
+const MENU_ITEM_SELECTOR = '[role="menuitem"]';
 
 function normalizeWhitespace(value) {
   return value.replace(/\s+/g, " ").trim();
@@ -277,6 +281,30 @@ export function extractAuthorProfileUrl(postElement, author) {
   }
 }
 
+export function findPostOverflowButton(postElement) {
+  return postElement?.querySelector(OVERFLOW_BUTTON_SELECTOR) || null;
+}
+
+export function findFloatingPostMenu(root = document) {
+  return root?.querySelector(FLOATING_MENU_SELECTOR) || null;
+}
+
+export function findCopyLinkMenuItem(root = document) {
+  const menu = findFloatingPostMenu(root);
+
+  if (!menu) {
+    return null;
+  }
+
+  return (
+    Array.from(menu.querySelectorAll(MENU_ITEM_SELECTOR)).find((item) =>
+      normalizeWhitespace(item.textContent || "")
+        .toLowerCase()
+        .includes("copy link to post"),
+    ) || null
+  );
+}
+
 export function buildFingerprint(postElement, author) {
   const visibleText = normalizeWhitespace(postElement.textContent || "").slice(
     0,
@@ -291,9 +319,10 @@ export function buildNormalizedItem(
   author,
   repostMetadata,
   now = new Date(),
+  options = {},
 ) {
   return {
-    link: null,
+    link: options.link || null,
     author,
     author_profile_url: extractAuthorProfileUrl(postElement, author),
     reposted_by: repostMetadata.reposted_by,

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -7,8 +7,11 @@ import {
   extractPostedTime,
   extractPostText,
   extractRepostMetadata,
+  findCopyLinkMenuItem,
   findFeedContainer,
+  findFloatingPostMenu,
   findPostElements,
+  findPostOverflowButton,
   isPromotedPost,
   isSuggestedPost,
   scanFeedPosts,
@@ -21,6 +24,12 @@ const FEED_FIXTURE = `
     <div role="listitem" data-post-id="organic-1">
       <div>
         <p>Regular organic post</p>
+        <button
+          type="button"
+          aria-label="Open control menu for post by Gonzalo Corbijn"
+        >
+          Open menu
+        </button>
         <a href="https://www.linkedin.com/in/gonzalo-corbijn/">Gonzalo Corbijn</a>
         <span aria-hidden="true">
           Gonzalo Corbijn
@@ -113,6 +122,12 @@ const FEED_FIXTURE = `
       <span data-testid="expandable-text-box">Author should come from paragraph marker.</span>
     </div>
   </div>
+  <div popover="manual">
+    <div role="menu">
+      <div role="menuitem">Save</div>
+      <div role="menuitem">Copy link to post</div>
+    </div>
+  </div>
 `;
 
 function setupDocument() {
@@ -167,6 +182,17 @@ describe("LinkedIn feed smoke extraction", () => {
       "https://www.linkedin.com/in/gonzalo-corbijn/",
     );
     expect(extractAuthorProfileUrl(posts[2], "Ada Lovelace")).toBeNull();
+  });
+
+  it("finds the overflow button and floating copy-link menu item", () => {
+    const document = setupDocument();
+    const posts = findPostElements(findFeedContainer(document));
+
+    expect(findPostOverflowButton(posts[0])).not.toBeNull();
+    expect(findFloatingPostMenu(document)).not.toBeNull();
+    expect(findCopyLinkMenuItem(document)?.textContent).toContain(
+      "Copy link to post",
+    );
   });
 
   it("detects repost metadata without misclassifying social suggestions", () => {


### PR DESCRIPTION
## Summary
- capture LinkedIn post permalinks during crawl using the overflow menu and the "Copy link to post" action
- move completed backlog work out of backlog.md into backlog.done.md and keep backlog.md focused on pending items
- make Gemini AI retry/backoff resilient in MV3 by scheduling wake-up alarms instead of relying on an in-worker timeout

## Verification
- npm test
- npm run build

## Notes
- adds the Manifest V3 `alarms` permission so AI validation can resume after rate-limit backoff
- permalink capture now depends on the floating post menu and clipboard copy flow rather than preload/embed links
