### PR TITLE
Close BL-004 and harden permalink extraction

### DIFF
--- a/backlog.done.md
+++ b/backlog.done.md
@@ -11,3 +11,16 @@ Objetivo: decidir si un post ya recolectado realmente nos interesa para comentar
 - Cada post que pase el primer filtro debe recibir una decision adicional de interes basada en Gemini.
 - La decision debe quedar registrada junto al post para trazabilidad.
 - El pipeline debe permitir continuar aunque falle la llamada al servicio (fallback controlado).
+
+## BL-004: Recuperar extraccion del link/permalink del post
+
+Estado: terminado.
+
+Revisar y restaurar la extraccion del link canonico del post en el flujo normalizado del harvester.
+
+### Resultado entregado
+- Se recupero la extraccion del permalink en el flujo normalizado.
+- El export final dejo de producir `link: null` de forma sistematica en la corrida validada.
+- Se endurecio la resolucion del menu flotante de LinkedIn y el manejo del clipboard.
+- Se elimino el patron alternado de exito/fallo causado por el cierre del menu via toggle del mismo overflow button.
+- Se agrego y actualizo cobertura de tests para proteger el comportamiento del extractor.

--- a/backlog.md
+++ b/backlog.md
@@ -34,19 +34,6 @@ Caso detectado:
   - crawler interrumpido por el usuario
   - crawler detenido por fragilidad o estancamiento
 
-## BL-004: Recuperar extraccion del link/permalink del post
-
-Revisar y restaurar la extraccion del link canonico del post en el flujo normalizado del harvester.
-
-Caso detectado:
-- El campo `link` hoy queda en `null` en el flujo actual, por lo que la extraccion del permalink no esta implementada o se perdio en algun cambio previo.
-
-### Resultado esperado
-- Identificar el selector o anchor correcto del permalink del post en LinkedIn.
-- Extraer y persistir el link canonico en el campo `link` del item normalizado.
-- Verificar que el export raw y enriched conserven el permalink correctamente.
-- Agregar cobertura de tests para evitar que vuelva a quedar en `null` sin detectar la regresion.
-
 ## BL-005: Normalizar formatter/linter en package.json y rules of engagement
 
 Resolver la desalineacion actual entre documentacion y tooling: el repo exige `npm run lint`, `npm run format` y `npm run format:write` en README, checklist y repo rules, pero esos scripts no existen hoy en `package.json`.
@@ -186,3 +173,20 @@ Contexto:
 - Reducir el tamaño y complejidad ciclomática del entrypoint, dejando `content.js` como composicion/orquestacion liviana.
 - Mantener el comportamiento actual sin regresiones funcionales.
 - Agregar o ajustar tests donde haga falta para cubrir la nueva modularizacion y proteger el refactor.
+
+## BL-013: Recuperar deteccion correcta de `reposted_by` en reposts del feed
+
+Revisar y corregir la deteccion de reposts en el extractor del feed, porque hoy hay evidencia de posts compartidos/reposteados que terminan normalizados como si fueran posts originales.
+
+Caso detectado:
+- Algunos posts que parecen ser reposts terminan con `is_repost: false` y `reposted_by: null`.
+- En esos casos puede terminar persistiendose un permalink valido pero de una superficie distinta del post compartido, enmascarando el problema real de clasificacion.
+
+### Resultado esperado
+- Detectar correctamente cuando un item del feed es un repost/share y no un post original.
+- Poblar `reposted_by` con el nombre correcto de quien compartio el post cuando LinkedIn lo exponga.
+- Mantener `is_repost` alineado con `reposted_by` y con la semantica real del item en el feed.
+- Agregar fixtures/tests que cubran al menos:
+  - repost clasico con texto tipo `X reposted this`
+  - variantes actuales del markup de LinkedIn para shares/reposts
+  - casos sociales tipo `supports this` o `loves this` que no deben confundirse con repost

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkedin-post-gatherer",
-  "version": "0.1.0",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkedin-post-gatherer",
-      "version": "0.1.0",
+      "version": "0.8.4",
       "devDependencies": {
         "jsdom": "^26.0.0",
         "vite": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkedin-post-gatherer",
-  "version": "0.1.0",
+  "version": "0.8.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LinkedIn Intelligence Harvester",
-  "version": "0.1.0",
+  "version": "0.8.4",
   "description": "Collects organic LinkedIn posts, extracts authors, and exports the current batch as JSON.",
   "permissions": ["storage", "activeTab", "downloads", "tabs", "alarms"],
   "host_permissions": [

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -1100,25 +1100,37 @@
       return null;
     }
 
+    const preExistingMenu = findFloatingPostMenu();
+
+    if (preExistingMenu) {
+      logPage("permalink-closing-stale-menu");
+      dismissFloatingMenu();
+      await waitForElementToDisappear(findFloatingPostMenu, 1000);
+    }
+
     logPage("permalink-menu-opening");
     overflowButton.click();
 
-    const menuElement = await waitForElement(findFloatingPostMenu, 1200);
+    const menuResolution = await waitForCopyLinkMenuItem({
+      previousMenu: preExistingMenu,
+      timeoutMs: 2500,
+      pollMs: 100,
+    });
+    const menuElement = menuResolution?.menuElement || null;
+    const copyLinkItem = menuResolution?.copyLinkItem || null;
 
     if (!menuElement) {
       logPage("permalink-menu-timeout");
       return null;
     }
 
-    logPage("permalink-menu-found");
-    const copyLinkItem = findCopyLinkMenuItem(menuElement);
-
     if (!copyLinkItem) {
-      logPage("permalink-copy-link-item-missing");
-      closeFloatingMenu(overflowButton);
+      logPage("permalink-copy-link-item-timeout");
+      await closeFloatingMenu();
       return null;
     }
 
+    logPage("permalink-menu-found");
     const clipboardBeforeClick = normalizeCapturedPermalink(
       await readClipboardPermalink(0),
     );
@@ -1131,7 +1143,7 @@
       timeoutMs: 2200,
       pollMs: 100,
     });
-    closeFloatingMenu(overflowButton);
+    await closeFloatingMenu();
 
     if (clipboardUrl) {
       if (seenLinks.has(clipboardUrl)) {
@@ -1170,8 +1182,29 @@
     return null;
   }
 
-  function closeFloatingMenu(overflowButton) {
-    overflowButton?.click();
+  async function closeFloatingMenu() {
+    if (!findFloatingPostMenu()) {
+      return;
+    }
+
+    dismissFloatingMenu();
+    await waitForElementToDisappear(findFloatingPostMenu, 1000);
+  }
+
+  function dismissFloatingMenu() {
+    try {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Escape",
+          code: "Escape",
+          keyCode: 27,
+          which: 27,
+          bubbles: true,
+        }),
+      );
+    } catch {
+      document.body?.click();
+    }
   }
 
   function normalizeCapturedPermalink(value) {
@@ -1241,6 +1274,62 @@
     return null;
   }
 
+  async function waitForElementToDisappear(getElement, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      if (!getElement()) {
+        return true;
+      }
+
+      await sleep(50);
+    }
+
+    return !getElement();
+  }
+
+  async function waitForCopyLinkMenuItem(options = {}) {
+    const previousMenu = options.previousMenu || null;
+    const timeoutMs = Math.max(300, options.timeoutMs || 2000);
+    const pollMs = Math.max(50, options.pollMs || 100);
+    const deadline = Date.now() + timeoutMs;
+    let lastMenuElement = null;
+
+    while (Date.now() < deadline) {
+      const menuElement = findFloatingPostMenu();
+
+      if (menuElement) {
+        lastMenuElement = menuElement;
+
+        const copyLinkItem = findCopyLinkMenuItem(menuElement);
+        const menuChanged = menuElement !== previousMenu;
+
+        if (copyLinkItem && (menuChanged || !previousMenu)) {
+          return {
+            menuElement,
+            copyLinkItem,
+          };
+        }
+
+        if (copyLinkItem) {
+          return {
+            menuElement,
+            copyLinkItem,
+          };
+        }
+      }
+
+      await sleep(pollMs);
+    }
+
+    return {
+      menuElement: lastMenuElement,
+      copyLinkItem: lastMenuElement
+        ? findCopyLinkMenuItem(lastMenuElement)
+        : null,
+    };
+  }
+
   function extractProfileSignals() {
     const roleSelectors = [
       ".text-body-medium.break-words",
@@ -1295,11 +1384,6 @@
 
       if (isPromotedPost(postElement)) {
         skippedItems.push("promoted");
-        continue;
-      }
-
-      if (isSuggestedPost(postElement)) {
-        skippedItems.push("suggested");
         continue;
       }
 

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -343,10 +343,6 @@ export function analyzePostElement(postElement, now = new Date()) {
     return { status: "skipped", reason: "promoted" };
   }
 
-  if (isSuggestedPost(postElement)) {
-    return { status: "skipped", reason: "suggested" };
-  }
-
   const author = extractAuthor(postElement);
 
   if (!author) {

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -151,14 +151,17 @@ describe("LinkedIn feed smoke extraction", () => {
     expect(isPromotedPost(posts[0])).toBe(false);
   });
 
-  it("filters suggested content separately from promoted posts", () => {
+  it("keeps suggested content and only filters promoted posts", () => {
     const document = setupDocument();
     const posts = findPostElements(findFeedContainer(document));
 
     expect(isSuggestedPost(posts[7])).toBe(true);
-    expect(analyzePostElement(posts[7])).toEqual({
-      status: "skipped",
-      reason: "suggested",
+    expect(analyzePostElement(posts[7])).toMatchObject({
+      status: "accepted",
+      item: {
+        author: "Muhammad Haseeb",
+        post_text: "Should be skipped as suggested.",
+      },
     });
   });
 
@@ -238,10 +241,9 @@ describe("LinkedIn feed smoke extraction", () => {
     });
     const secondPass = scanFeedPosts(container, { processedElements });
 
-    expect(firstPass.acceptedItems).toHaveLength(7);
+    expect(firstPass.acceptedItems).toHaveLength(8);
     expect(firstPass.skippedItems).toContain("promoted");
     expect(firstPass.skippedItems).toContain("missing-author");
-    expect(firstPass.skippedItems).toContain("suggested");
     expect(firstPass.acceptedItems[0]).toMatchObject({
       author: "Gonzalo Corbijn",
       author_profile_url: "https://www.linkedin.com/in/gonzalo-corbijn/",
@@ -251,23 +253,40 @@ describe("LinkedIn feed smoke extraction", () => {
       post_text: "Full organic text with a hidden ending.",
       posted_time: "4h",
     });
-    expect(firstPass.acceptedItems[3]).toMatchObject({
+    expect(
+      firstPass.acceptedItems.find((item) => item.author === "Liz Fong-Jones"),
+    ).toMatchObject({
       author: "Liz Fong-Jones",
       is_repost: true,
       reposted_by: "Charity Majors",
     });
-    expect(firstPass.acceptedItems[4]).toMatchObject({
+    expect(
+      firstPass.acceptedItems.find(
+        (item) => item.post_text === "Should be skipped as suggested.",
+      ),
+    ).toMatchObject({
+      author: "Muhammad Haseeb",
+      post_text: "Should be skipped as suggested.",
+    });
+    expect(
+      firstPass.acceptedItems.find((item) => item.author === "Cruz Gamboa"),
+    ).toMatchObject({
       author: "Cruz Gamboa",
       is_repost: false,
       reposted_by: null,
     });
-    expect(firstPass.acceptedItems[5]).toMatchObject({
+    expect(
+      firstPass.acceptedItems.find((item) => item.author === "Patty Fonacier"),
+    ).toMatchObject({
       author: "Patty Fonacier",
       post_text: "Author should come from aria-label.",
     });
-    expect(firstPass.acceptedItems[6]).toMatchObject({
+    expect(
+      firstPass.acceptedItems.find(
+        (item) => item.post_text === "Author should come from paragraph marker.",
+      ),
+    ).toMatchObject({
       author: "Muhammad Haseeb",
-      post_text: "Author should come from paragraph marker.",
     });
     expect(secondPass.acceptedItems).toHaveLength(0);
   });
@@ -283,10 +302,10 @@ describe("LinkedIn feed smoke extraction", () => {
     const firstMerge = mergeNewItems(101, acceptedItems);
     const secondMerge = mergeNewItems(101, acceptedItems);
 
-    expect(firstMerge.addedCount).toBe(7);
+    expect(firstMerge.addedCount).toBe(8);
     expect(secondMerge.addedCount).toBe(0);
     expect(getSerializableState(101).aiCounts).toEqual({
-      pending: 7,
+      pending: 8,
       interested: 0,
       not_interested: 0,
       unknown: 0,


### PR DESCRIPTION
## Summary
- harden LinkedIn permalink extraction and menu handling
- stop filtering Suggested posts and keep filtering only Promoted
- bump extension version to 0.8.4
- move BL-004 to done backlog and add a new backlog item for reposted_by detection

## Testing
- npm test
- npm run build