### PR TITLE
Docs: move BL-016 from backlog to done

### DIFF
--- a/backlog.done.md
+++ b/backlog.done.md
@@ -125,4 +125,16 @@ Revisar y corregir la deteccion de reposts en el extractor del feed, porque habi
 - Se agregaron y ampliaron smoke tests para cubrir repost clasico, variantes mas cercanas al DOM actual y casos no-repost.
 - Se incorporo un fixture real adicional del feed extraido de LinkedIn para proteger el extractor frente a drift de markup.
 
+## BL-016: Simplificar la UI inyectada para que sea mas funcional y menos dashboard pesado
+
+Estado: terminado.
+
+### Resultado entregado
+
+- Se simplifico de forma agresiva la UI inyectada para priorizar run control, estado de corrida y activity.
+- Se redujo el peso visual del panel (tipografias, espaciado, cards y jerarquia) para una lectura mas rapida en uso real.
+- Se movieron `Enrichment` y `AI validation` a secciones secundarias colapsables por defecto, manteniendo detalle accesible bajo demanda.
+- Se agregaron resúmenes compactos de estado para AI y enrichment en los encabezados colapsados.
+- Se mantuvo la compatibilidad del wiring operativo existente: start/stop, target, presets, export y activity log.
+
 

--- a/backlog.md
+++ b/backlog.md
@@ -99,24 +99,6 @@ Caso detectado:
 - Mantener la popup como una superficie de configuracion y debug, pero mas legible y mas practica para uso repetido.
 - Ajustar estilos y spacing para que la experiencia sea consistente en ventanas chicas sin perder densidad de informacion.
 
-## BL-016: Simplificar la UI inyectada para que sea mas funcional y menos dashboard pesado
-
-La UI inyectada hoy resolvio demasiado dentro de una sola superficie y termino demasiado cargada.
-
-Caso detectado:
-
-- La vista inyectada se siente muy parecida a un dashboard grande, con demasiadas metricas y controles juntos.
-- El resultado es visualmente pesado y poco enfocado para la operacion real.
-- Queremos priorizar funcionalidad util para correr, parar, seguir y entender el proceso, no un panel saturado de widgets.
-
-### Resultado esperado
-
-- Redisenar la UI inyectada con un enfoque mas funcional y menos “dashboard loco”.
-- Reducir ruido visual y concentrar la superficie en controles y estados realmente accionables.
-- Reorganizar metrica, activity, enrichment y AI para que el panel sea mas legible y jerarquico.
-- Mantener lo necesario para operar la corrida, pero recortar o simplificar lo accesorio que hoy ensucia la experiencia.
-- Buscar una interfaz que se sienta mas liviana de escanear en uso real, sin perder capacidad de debug.
-
 ## BL-012: Refactor estructural de `src/content/linkedin/content.js` con single responsibility real
 
 Refactorizar `src/content/linkedin/content.js`, que hoy concentra demasiadas responsabilidades y se volvio un archivo gigante, dificil de mantener, depurar y testear.


### PR DESCRIPTION
## Summary
- move `BL-016` out of `backlog.md` since implementation is already merged
- add `BL-016` to `backlog.done.md` with explicit delivered outcomes
- keep backlog docs aligned with current repository state

## Test plan
- [x] Docs-only review of `backlog.md` and `backlog.done.md`
- [ ] Optional maintainer check: confirm BL-016 appears only in done backlog