### PR TITLE
BL-017: preserve unicode post text in exports

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -709,7 +709,11 @@ async function runAiValidation(tabId, run) {
     const stateBeforeChunk = getSerializableState(tabId);
     const currentChunkIndex = Math.min(
       (stateBeforeChunk.aiQueue?.completedChunks || 0) + 1,
-      Math.max(1, stateBeforeChunk.aiQueue?.totalChunks || Math.ceil(eligibleItems.length / AI_RATE_LIMIT.chunkSize))
+      Math.max(
+        1,
+        stateBeforeChunk.aiQueue?.totalChunks ||
+          Math.ceil(eligibleItems.length / AI_RATE_LIMIT.chunkSize)
+      )
     );
     const processingState = await setAiQueueState(tabId, {
       phase: AI_QUEUE_PHASES.running,
@@ -725,10 +729,8 @@ async function runAiValidation(tabId, run) {
       `AI validation chunk ${currentChunkIndex}/${processingState.aiQueue.totalChunks} running for ${chunk.length} posts.`
     );
 
-    const attempts = Math.max(
-      ...chunk.map((item) => Number(item.interest_validation?.attempts || 0)),
-      0
-    ) + 1;
+    const attempts =
+      Math.max(...chunk.map((item) => Number(item.interest_validation?.attempts || 0)), 0) + 1;
     logServiceWorkerEvent("ai-validation-chunk-started", {
       tabId,
       chunkIndex: currentChunkIndex,
@@ -792,7 +794,11 @@ async function runAiValidation(tabId, run) {
           tabId,
           chunk.map((item) => ({
             fingerprint: item.fingerprint,
-            validationPatch: buildValidationResult(AI_STATUS.unknown, attempts, normalizedError.kind),
+            validationPatch: buildValidationResult(
+              AI_STATUS.unknown,
+              attempts,
+              normalizedError.kind
+            ),
           }))
         );
         const failedState = await setAiQueueState(tabId, {
@@ -1117,7 +1123,7 @@ function waitForTabLoad(tabId) {
 }
 
 async function downloadJsonExport({ items, filename }) {
-  const json = JSON.stringify(items, null, 2);
+  const json = serializeExportItems(items);
   const dataUrl = `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
   const downloadId = await chrome.downloads.download({
     url: dataUrl,

--- a/src/background/gemini.js
+++ b/src/background/gemini.js
@@ -94,7 +94,10 @@ export async function validatePostsInterestBulk(items, config, options = {}) {
 
   const payload = await response.json();
   const rawText = extractCandidateText(payload);
-  const interestedIds = parseGeminiBulkDecision(rawText, items.map((item) => item.fingerprint));
+  const interestedIds = parseGeminiBulkDecision(
+    rawText,
+    items.map((item) => item.fingerprint)
+  );
 
   return {
     interestedIds,

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -1,3 +1,10 @@
+import {
+  cleanPersonLabel as sharedCleanPersonLabel,
+  extractPostText as extractSharedPostText,
+  normalizeWhitespace as sharedNormalizeWhitespace,
+  stripExpandableSuffix as sharedStripExpandableSuffix,
+} from "../../shared/extractor.js";
+
 (function () {
   const FEED_SELECTOR = 'div[componentkey="container-update-list_mainFeed-lazy-container"]';
   const POST_SELECTOR = 'div[role="listitem"]';
@@ -665,7 +672,7 @@
   }
 
   function normalizeWhitespace(value) {
-    return value.replace(/\s+/g, " ").trim();
+    return sharedNormalizeWhitespace(value);
   }
 
   function escapeHtml(value) {
@@ -752,7 +759,9 @@
     }
 
     if (uiState.aiQueue.phase === AI_QUEUE_PHASES.failed) {
-      return uiState.aiQueue.lastMessage || "Last AI validation chunk failed and was marked unknown.";
+      return (
+        uiState.aiQueue.lastMessage || "Last AI validation chunk failed and was marked unknown."
+      );
     }
 
     if (uiState.aiQueue.phase === AI_QUEUE_PHASES.cancelled) {
@@ -817,31 +826,11 @@
   }
 
   function stripExpandableSuffix(text) {
-    return text
-      .replace(/(?:…|\.{3})\s*more\s*$/i, " ")
-      .replace(/\s+/g, " ")
-      .trim();
+    return sharedStripExpandableSuffix(text);
   }
 
   function cleanPersonLabel(text) {
-    if (!text) {
-      return null;
-    }
-
-    let cleaned = normalizeWhitespace(text);
-    cleaned = cleaned.replace(/\bOpen to work\b/gi, " ");
-    cleaned = cleaned.replace(/\bHiring\b/gi, " ");
-    cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
-    cleaned = cleaned.replace(/\bPremium\b/gi, " ");
-    cleaned = cleaned.replace(/\bProfile\b\s*$/gi, " ");
-    cleaned = cleaned.replace(/[,:]+/g, " ");
-    cleaned = cleaned.replace(/â€¢/g, " ");
-    cleaned = cleaned.replace(/[•·]+/g, " ");
-    cleaned = cleaned.replace(/â€¢|Â·/g, " ");
-    cleaned = cleaned.replace(/\s+[•·]+\s*$/g, " ");
-    cleaned = normalizeWhitespace(cleaned);
-
-    return cleaned || null;
+    return sharedCleanPersonLabel(text);
   }
 
   function hasRelationshipMarker(text) {
@@ -1006,7 +995,7 @@
 
     for (const marker of RELATIONSHIP_MARKERS) {
       const markerPattern = new RegExp(
-        "\\s*[•\\-·]?\\s*" + escapeRegExp(marker) + "(?:\\s|$)",
+        `\\s*[\\u2022\\-\\u00B7]?\\s*${escapeRegExp(marker)}(?:\\s|$)`,
         "gi"
       );
 
@@ -1211,14 +1200,8 @@
   }
 
   function extractPostText(postElement) {
-    const textBox = postElement.querySelector('[data-testid="expandable-text-box"]');
-
-    if (!textBox) {
-      return null;
-    }
-
-    const text = stripExpandableSuffix(textBox.textContent || "");
-    return text || null;
+    const text = extractSharedPostText(postElement);
+    return stripExpandableSuffix(text || "") || null;
   }
 
   function extractPostedTime(postElement) {
@@ -2689,7 +2672,8 @@
   }
 
   function canRunAiValidation() {
-    const hasEligiblePosts = (uiState.aiCounts.pending || 0) > 0 || (uiState.aiCounts.unknown || 0) > 0;
+    const hasEligiblePosts =
+      (uiState.aiCounts.pending || 0) > 0 || (uiState.aiCounts.unknown || 0) > 0;
 
     return (
       hasEligiblePosts &&

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -7,23 +7,33 @@ const POSTED_TIME_PATTERN = /^(now|\d+\s*(?:s|m|h|d|w|mo|y))\b/i;
 const OVERFLOW_BUTTON_SELECTOR = 'button[aria-label*="Open control menu for post"]';
 const FLOATING_MENU_SELECTOR = 'div[popover="manual"] [role="menu"]';
 const MENU_ITEM_SELECTOR = '[role="menuitem"]';
+const POST_TEXT_BLOCK_TAGS = new Set(["P", "DIV", "LI"]);
 
-function normalizeWhitespace(value) {
-  return value.replace(/\s+/g, " ").trim();
+export function normalizeWhitespace(value) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function stripExpandableSuffix(text) {
+export function stripExpandableSuffix(text) {
+  if (!text) {
+    return "";
+  }
+
   return text
-    .replace(/(?:…|\.{3})\s*more\s*$/i, " ")
-    .replace(/\s+/g, " ")
+    .replace(/(?:\u2026|\.{3})[^\S\n]*more[^\S\n]*$/iu, "")
+    .replace(/[^\S\n]+\n/g, "\n")
+    .replace(/\n[^\S\n]+/g, "\n")
+    .replace(/[^\S\n]{2,}/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
     .trim();
 }
 
-function cleanPersonLabel(text) {
+export function cleanPersonLabel(text) {
   if (!text) {
     return null;
   }
@@ -38,6 +48,8 @@ function cleanPersonLabel(text) {
   cleaned = cleaned.replace(/[•·]+/g, " ");
   cleaned = cleaned.replace(/â€¢|Ã¢â‚¬Â¢|Ã‚Â·/g, " ");
   cleaned = cleaned.replace(/\s+[•·]+\s*$/g, " ");
+  cleaned = cleaned.replace(/[\u2022\u00B7]+/g, " ");
+  cleaned = cleaned.replace(/\s+[\u2022\u00B7]+\s*$/g, " ");
   cleaned = normalizeWhitespace(cleaned);
 
   return cleaned || null;
@@ -110,11 +122,20 @@ function removeRelationshipMarker(text) {
   let hadMarker = false;
 
   for (const marker of RELATIONSHIP_MARKERS) {
+    const canonicalMarkerPattern = new RegExp(
+      `\\s*[\\u2022\\-\\u00B7]?\\s*${escapeRegExp(marker)}(?:\\s|$)`,
+      "gi"
+    );
     const markerPattern = new RegExp(`\\s*[•\\-·]?\\s*${escapeRegExp(marker)}(?:\\s|$)`, "gi");
 
     if (markerPattern.test(cleaned)) {
       hadMarker = true;
       cleaned = cleaned.replace(markerPattern, " ");
+    }
+
+    if (canonicalMarkerPattern.test(cleaned)) {
+      hadMarker = true;
+      cleaned = cleaned.replace(canonicalMarkerPattern, " ");
     }
   }
 
@@ -332,15 +353,66 @@ export function extractRepostMetadata(postElement, author = null) {
   };
 }
 
-export function extractPostText(postElement) {
-  const textBox = postElement.querySelector('[data-testid="expandable-text-box"]');
+function appendPostTextNode(node, fragments) {
+  if (!node) {
+    return;
+  }
 
+  if (node.nodeType === 3) {
+    fragments.push((node.textContent || "").replace(/\u00A0/g, " "));
+    return;
+  }
+
+  if (node.nodeType !== 1) {
+    return;
+  }
+
+  const element = node;
+
+  if (element.tagName === "BUTTON") {
+    return;
+  }
+
+  if (element.tagName === "BR") {
+    fragments.push("\n");
+    return;
+  }
+
+  for (const childNode of element.childNodes) {
+    appendPostTextNode(childNode, fragments);
+  }
+
+  if (POST_TEXT_BLOCK_TAGS.has(element.tagName)) {
+    fragments.push("\n\n");
+  }
+}
+
+function normalizePostTextWithBreaks(text) {
+  return String(text || "")
+    .replace(/\r\n?/g, "\n")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+export function extractPostTextWithBreaks(textBox) {
   if (!textBox) {
     return null;
   }
 
-  const text = stripExpandableSuffix(textBox.textContent || "");
+  const fragments = [];
+
+  for (const childNode of textBox.childNodes) {
+    appendPostTextNode(childNode, fragments);
+  }
+
+  const text = stripExpandableSuffix(normalizePostTextWithBreaks(fragments.join("")));
   return text || null;
+}
+
+export function extractPostText(postElement) {
+  const textBox = postElement.querySelector('[data-testid="expandable-text-box"]');
+  return extractPostTextWithBreaks(textBox);
 }
 
 export function extractPostedTime(postElement) {

--- a/src/ui/popup/style.css
+++ b/src/ui/popup/style.css
@@ -189,7 +189,6 @@ h1 {
   gap: 10px;
 }
 
-
 .primary-button:hover {
   background: #0052cc;
   transform: translateY(-1px);

--- a/test/export.encoding.test.js
+++ b/test/export.encoding.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { serializeExportItems } from "../src/shared/export.js";
+
+const EXPECTED_UNICODE_POST_TEXT =
+  "\u201CHola\u201D \u2014 lanzamiento \u{1F680}\n\nL\u00ednea con emoji \u{1F600}\nSegunda l\u00ednea unida\n\nBloque final con acento: p\u00e1rrafo";
+
+describe("Export encoding", () => {
+  it("preserves unicode and paragraph breaks during serialization", () => {
+    const items = [
+      {
+        post_text: EXPECTED_UNICODE_POST_TEXT,
+        author: "Ada Lovelace",
+      },
+    ];
+
+    const json = serializeExportItems(items);
+
+    expect(JSON.parse(json)[0].post_text).toBe(EXPECTED_UNICODE_POST_TEXT);
+    expect(json).toContain("\\n\\n");
+  });
+
+  it("keeps the current data-url export round trip intact", () => {
+    const items = [
+      {
+        post_text: EXPECTED_UNICODE_POST_TEXT,
+        author: "Ada Lovelace",
+      },
+    ];
+
+    const json = serializeExportItems(items);
+    const dataUrl = `data:application/json;charset=utf-8,${encodeURIComponent(json)}`;
+    const decodedJson = decodeURIComponent(dataUrl.split(",")[1]);
+    const parsed = JSON.parse(decodedJson);
+
+    expect(decodedJson).toBe(json);
+    expect(parsed[0].post_text).toBe(EXPECTED_UNICODE_POST_TEXT);
+    expect(decodedJson).not.toContain("Ã");
+    expect(decodedJson).not.toContain("â€");
+  });
+});

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -7,6 +7,7 @@ import {
   extractAuthorProfileUrl,
   extractPostedTime,
   extractPostText,
+  extractPostTextWithBreaks,
   extractRepostMetadata,
   findCopyLinkMenuItem,
   findFeedContainer,
@@ -23,6 +24,9 @@ import { getSerializableState, mergeNewItems } from "../src/shared/state.js";
 const REAL_FEED_FIXTURE = JSON.parse(
   readFileSync("test/fixtures/linkedin-feedcurrent-2026-03-23.json", "utf8")
 );
+const UNICODE_POST_FIXTURE = readFileSync("test/fixtures/post-text-unicode.html", "utf8");
+const EXPECTED_UNICODE_POST_TEXT =
+  "\u201CHola\u201D \u2014 lanzamiento \u{1F680}\n\nL\u00ednea con emoji \u{1F600}\nSegunda l\u00ednea unida\n\nBloque final con acento: p\u00e1rrafo";
 
 const FEED_FIXTURE = `
   <div componentkey="container-update-list_mainFeed-lazy-container">
@@ -181,6 +185,12 @@ function setupRealFeedPost(postIndex) {
   }).window.document.querySelector('div[role="listitem"]');
 }
 
+function setupUnicodePostDocument() {
+  return new JSDOM(UNICODE_POST_FIXTURE, {
+    url: "https://www.linkedin.com/feed/",
+  }).window.document;
+}
+
 describe("LinkedIn feed smoke extraction", () => {
   it("finds the feed container and list items", () => {
     const document = setupDocument();
@@ -273,6 +283,33 @@ describe("LinkedIn feed smoke extraction", () => {
 
     expect(extractPostText(posts[0])).toBe("Full organic text with a hidden ending.");
     expect(extractPostText(posts[2])).toBeNull();
+  });
+
+  it("preserves unicode characters and paragraph breaks in post text", () => {
+    const document = setupUnicodePostDocument();
+    const post = document.querySelector('[data-post-id="unicode-post"]');
+    const textBox = post.querySelector('[data-testid="expandable-text-box"]');
+
+    expect(extractPostTextWithBreaks(textBox)).toBe(EXPECTED_UNICODE_POST_TEXT);
+    expect(extractPostText(post)).toBe(EXPECTED_UNICODE_POST_TEXT);
+  });
+
+  it("returns null when the expandable text box has no useful text", () => {
+    const document = new JSDOM(
+      `
+        <div role="listitem">
+          <span data-testid="expandable-text-box">
+            <button type="button">&#8230; more</button>
+            &nbsp;
+          </span>
+        </div>
+      `,
+      {
+        url: "https://www.linkedin.com/feed/",
+      }
+    ).window.document;
+
+    expect(extractPostText(document.querySelector('[role="listitem"]'))).toBeNull();
   });
 
   it("extracts posted time when LinkedIn exposes a relative timestamp", () => {

--- a/test/fixtures/post-text-unicode.html
+++ b/test/fixtures/post-text-unicode.html
@@ -1,0 +1,10 @@
+<div componentkey="container-update-list_mainFeed-lazy-container">
+  <div role="listitem" data-post-id="unicode-post">
+    <div data-testid="expandable-text-box">
+      <p>&#8220;Hola&#8221; &#8212; lanzamiento &#128640;</p>
+      <p>L&#237;nea con emoji &#128512;<br />Segunda l&#237;nea&nbsp;unida</p>
+      <div>Bloque final con acento: p&#225;rrafo</div>
+      <button type="button">&#8230; more</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- preserve Unicode characters and paragraph breaks when extracting `post_text`
- reuse the shared extractor/text normalizers from the LinkedIn content script
- make export downloads use the shared serializer and add regression coverage for Unicode/data-url round trips

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run prepush`

Closes #24