### PR TITLE
Refine result download and enrichment workflow

### DIFF
--- a/.agents/skills/product-manager/SKILL.md
+++ b/.agents/skills/product-manager/SKILL.md
@@ -7,7 +7,7 @@ Tu mision exclusiva es definir el "QUE" y el "POR QUE" de una iniciativa. Tienes
 1. **No codigo:** Tienes prohibido escribir codigo, proponer nombres de funciones, variables o interfaces tecnicas.
 2. **No archivos:** No busques ni menciones rutas de archivos del repositorio. El repositorio es una caja negra para ti.
 3. **No stack:** No menciones frameworks, bases de datos, librerias o decisiones de arquitectura.
-4. **Siempre delegar el como:** Si el usuario te pregunta "como lo implementarias", debes responder: _"Esa es una decision para el Tech Lead / Arquitecto en la siguiente fase. Mi objetivo aqui es definir que debe lograr el sistema."_ 
+4. **Siempre delegar el como:** Si el usuario te pregunta "como lo implementarias", debes responder: _"Esa es una decision para el Tech Lead / Arquitecto en la siguiente fase. Mi objetivo aqui es definir que debe lograr el sistema."_
 
 ## Regla principal: entrevistar hasta tener claridad
 

--- a/CODEX_PROJECT.md
+++ b/CODEX_PROJECT.md
@@ -27,7 +27,7 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
 3. Exclude promoted posts, polls, and suggested content before capture.
 4. Extract raw post metadata into a stable normalized structure.
 5. Accumulate deduplicated results in local extension state.
-6. Expose progress in the popup UI and export either a raw or enriched `JSON` payload for downstream manual use.
+6. Expose progress in the popup UI and export the latest available result snapshot as a local `JSON` payload for downstream manual use.
 
 ## Product Boundaries
 
@@ -73,7 +73,7 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
 6. Extracted post data is normalized into a stable internal structure and sent through an explicit message contract to background logic.
 7. Background logic deduplicates and stores intermediate collection state, then optionally runs Gemini AI Studio validation as a manual post-capture bulk job in fixed chunks.
 8. The floating panel and popup receive progress updates in the form `Posts identified: X / target`, while the popup also shows AI validation and author-enrichment status.
-9. When requested, export logic produces either a raw `linkedin_dump_[date].json` file or an enriched `linkedin_dump_[date]_enriched.json` file after sequential author enrichment.
+9. When requested, export logic produces `linkedin_crawl_result_[yyyymmdd-hhmmss].json` from the latest stable snapshot: raw, enriched, raw+AI, or enriched+AI.
 
 ## Core Operational Contracts
 
@@ -96,7 +96,9 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
   - `author_role`
   - `author_followers`
   - `author_weight`
+- `author_weight` in enriched exports may be `high`, `medium`, `low`, or `trivial`; `trivial` means enrichment did not find enough follower or role evidence to assign a meaningful importance signal.
 - AI validation may also persist an `interest_validation` block on each item for raw and enriched export flows.
+- Author enrichment and AI validation are separate sequential passes. They share the same tab-scoped dataset and the final download composes the latest enrichment snapshot with the latest AI validation overlay.
 - The requirements file contains the typo `is_repot`; the documented repository contract should use `is_repost`.
 - `type` should remain compatible with the current MVP expectation of organic content that passed the exclusion filters.
 - `post_text` should prefer the preloaded LinkedIn expandable text node so long posts can be captured without triggering UI expansion.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ Author enrichment cache for BL-002 is persisted in `chrome.storage.local` so rep
 - Wait randomized delays between `1.5s` and `3.5s`
 - Stop automatically at a user-defined accepted-post target with default `50` and supported range `1-200`
 - When LinkedIn stops yielding new accepted posts, pause for up to `20s` and retry multiple times before declaring the feed stalled
-- Export a local file named `linkedin_dump_[date].json`
-- Offer both `Export raw` for the current batch and `Export enriched` for a sequential author-enrichment pass with visible progress
+- Export a local file named `linkedin_crawl_result_[yyyymmdd-hhmmss].json`
+- Use `Download Result` in the LinkedIn panel to fetch the latest stable dataset snapshot: raw, enriched, raw+AI, or enriched+AI
+- Run author enrichment and AI validation as separate manual passes from the LinkedIn panel, each with explicit `Run` and `Cancel` controls
 - Enrich author metadata with `author_role`, `author_followers`, and `author_weight`
+- Enriched exports may classify authors as `trivial` when enrichment does not find followers or a strong enough role signal to support a meaningful priority
 - Optionally enrich each captured post with `interest_validation` using Gemini AI Studio
 - Run AI validation manually after capture in fixed chunks, with retry/backoff on quota and rate pressure
 
@@ -43,7 +45,7 @@ Author enrichment cache for BL-002 is persisted in `chrome.storage.local` so rep
 5. Watch the hero metric, status badge, long-wait counter, and activity log as collection progresses.
 6. Press `Stop` at any time or let the crawler stop automatically at the target.
 7. Optionally configure Gemini in the popup and run AI validation for the captured batch once the crawler stops.
-8. Export the current raw batch immediately, or start enriched export and monitor post/author progress until the enriched `JSON` is ready.
+8. Run author enrichment and AI validation sequentially from the LinkedIn panel as needed, then use `Download Result` to export the latest composed `JSON` snapshot.
 
 ## Standard Commands
 

--- a/REPO_WORK_RULES.md
+++ b/REPO_WORK_RULES.md
@@ -84,7 +84,7 @@ The repo gate is enforced as a pre-push check through `npm run prepush`.
 
 ## Output Contract Rules
 
-- The exported artifact is a local `JSON` file named in the shape `linkedin_dump_[date].json`.
+- The exported artifact is a local `JSON` file named in the shape `linkedin_crawl_result_[yyyymmdd-hhmmss].json`.
 - Each exported item should preserve the normalized MVP contract:
   - `link`
   - `author`

--- a/docs/diagrams/collection-flow.md
+++ b/docs/diagrams/collection-flow.md
@@ -13,26 +13,26 @@ flowchart TD
     I --> J[Normalize item shape]
     J --> K[Deduplicate and store locally]
     J --> K2[Capture ignored sample buffer]
-    K --> L[User triggers AI validation]
-    L --> M[Send chunked Gemini bulk request]
-    M --> N[Persist interest_validation]
-    N --> O[Emit AI activity to panel]
-    O --> P[Update popup counter]
-    P --> Q{Limit reached?}
-    Q -->|No| C
-    Q -->|Yes| R{Export mode}
-    R -->|Raw| S[Build raw JSON payload]
-S --> T["Download linkedin_dump_[date].json"]
-    R -->|Ignored debug| U[Build ignored-samples JSON preview]
-    U --> V[Copy or inspect in popup]
-    R -->|Enriched| W[Resolve unique authors]
-    W --> X[Reuse local author cache]
-    X --> Y[Open one LinkedIn profile tab at a time]
-    Y --> Z[Extract role and followers]
-    Z --> AA[Classify author weight]
-    AA --> AB[Update enrichment progress]
-    AB --> AC[Build enriched JSON payload]
-AC --> AD["Download linkedin_dump_[date]_enriched.json"]
+    K --> L{Optional manual pass}
+    L -->|Run enrichment| M[Resolve unique authors]
+    M --> N[Reuse local author cache]
+    N --> O[Open one LinkedIn profile tab at a time]
+    O --> P[Extract role and followers]
+    P --> Q[Classify author weight]
+    Q --> R[Persist enrichment snapshot]
+    K --> S[User triggers AI validation]
+    R --> S
+    S --> T[Reset items to pending and send chunked Gemini bulk request]
+    T --> U[Persist interest_validation]
+    U --> V[Emit AI activity to panel]
+    V --> W[Update popup counter]
+    W --> X{Limit reached?}
+    X -->|No| C
+    X -->|Yes| Y{Debug preview or download}
+    Y -->|Download result| Z[Compose latest snapshot]
+    Z --> AA["Download linkedin_crawl_result_[yyyymmdd-hhmmss].json"]
+    Y -->|Ignored debug| AB[Build ignored-samples JSON preview]
+    AB --> AC[Copy or inspect in popup]
 ```
 
 ## Notes
@@ -40,6 +40,8 @@ AC --> AD["Download linkedin_dump_[date]_enriched.json"]
 - Collection should be resumable and should not duplicate previously captured posts.
 - Failures in extraction should be observable and should not corrupt stored results.
 - Export is local-only in the current phase.
-- Enriched export is sequential and exposes explicit post/author progress while the raw batch remains available immediately.
+- The LinkedIn panel downloads the latest stable result snapshot and disables download while the crawler, enrichment, or AI validation is running.
+- Author enrichment is sequential, preserves partial progress on cancellation, and the latest download composes that snapshot with the latest AI validation overlay.
+- Enriched author classification may end in `trivial` when enrichment cannot find followers or a strong enough role signal; `low` is reserved for authors with real but weak follower evidence.
 - Non-organic feed items are excluded before they enter normalized storage.
-- Gemini validation runs after capture when the user starts it from the popup, uses fixed-size chunks, and may leave posts in `pending` or `unknown` when quota pressure or errors occur.
+- Gemini validation runs after capture, uses fixed-size chunks, and may leave posts in `pending` or `unknown` when quota pressure or errors occur.

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -14,7 +14,12 @@ import {
   buildAuthorSignalPatch,
   normalizeAuthorName,
 } from "../shared/author-weight.js";
-import { toEnrichedExportItem, toRawExportItem, serializeExportItems } from "../shared/export.js";
+import {
+  buildResultFilename,
+  serializeExportItems,
+  toEnrichedExportItem,
+  toRawExportItem,
+} from "../shared/export.js";
 import {
   buildValidationResult,
   getAiConfig,
@@ -35,14 +40,17 @@ import {
   finalizeStopCrawler,
   getAiValidationEligibleItems,
   getEnrichedItems,
+  getLatestResultItems,
   getSerializableState,
   markFeedReady,
   mergeNewItems,
   persistState,
+  resetAiValidationStatuses,
   resetDebugState,
   requestStopCrawler,
   setAiQueueState,
   setTargetCount,
+  syncEnrichedItems,
   startEnrichment,
   startCrawler,
   updateEnrichmentProgress,
@@ -101,6 +109,8 @@ async function handleMessage(message, sender) {
   if (
     tabId == null &&
     !tablessMessageTypes.has(message?.type) &&
+    message?.type !== MESSAGE_TYPES.downloadResultRequest &&
+    message?.type !== MESSAGE_TYPES.enrichmentStartRequest &&
     message?.type !== MESSAGE_TYPES.exportRawRequest &&
     message?.type !== MESSAGE_TYPES.exportEnrichedRequest
   ) {
@@ -251,8 +261,16 @@ async function handleMessage(message, sender) {
         return { ok: false, error: "Stop the crawler before running AI validation." };
       }
 
+      if (isEnrichmentRunning(state)) {
+        return { ok: false, error: "Wait for enrichment to finish before running AI validation." };
+      }
+
       if (activeAiValidationRuns.has(tabId)) {
         return { ok: true, started: false, aiQueue: state.aiQueue };
+      }
+
+      if (!state.count) {
+        return { ok: false, error: "No posts available for AI validation." };
       }
 
       if (configError) {
@@ -266,10 +284,12 @@ async function handleMessage(message, sender) {
         return { ok: false, error: configError, aiQueue: queueState.aiQueue };
       }
 
+      await chrome.alarms.clear(`${AI_RETRY_ALARM_PREFIX}${tabId}`);
+      await resetAiValidationStatuses(tabId);
       const eligibleItems = getAiValidationEligibleItems(tabId);
 
       if (!eligibleItems.length) {
-        return { ok: false, error: "No pending or unknown posts available for AI validation." };
+        return { ok: false, error: "No posts available for AI validation." };
       }
 
       const totalChunks = Math.ceil(eligibleItems.length / AI_RATE_LIMIT.chunkSize);
@@ -373,13 +393,18 @@ async function handleMessage(message, sender) {
       }
 
       const state = getSerializableState(tabId);
+
+      if (!state.count) {
+        return { ok: false, error: "No posts available to export." };
+      }
+
       logServiceWorkerEvent("raw-export-requested", {
         tabId,
         count: state.count,
       });
       const exportResult = await downloadJsonExport({
         items: state.items.map(toRawExportItem),
-        filename: buildExportFilename("raw"),
+        filename: buildExportFilename(),
       });
 
       logServiceWorkerEvent("raw-export-completed", {
@@ -391,39 +416,61 @@ async function handleMessage(message, sender) {
       return { type: MESSAGE_TYPES.exportResult, ...exportResult };
     }
 
-    case MESSAGE_TYPES.exportEnrichedRequest: {
+    case MESSAGE_TYPES.downloadResultRequest: {
       if (tabId == null) {
         return { ok: false, error: "tabId is required for export" };
       }
 
       const state = getSerializableState(tabId);
 
+      if (isProcessingLocked(state)) {
+        return { ok: false, error: "Wait for the active process to finish before downloading." };
+      }
+
+      const latestResult = getLatestResultItems(tabId);
+
+      if (!latestResult.items.length) {
+        return { ok: false, error: "No posts available to download." };
+      }
+
+      const items =
+        latestResult.mode === "enriched"
+          ? latestResult.items.map(toEnrichedExportItem)
+          : latestResult.items.map(toRawExportItem);
+      const exportResult = await downloadJsonExport({
+        items,
+        filename: buildExportFilename(),
+      });
+      logServiceWorkerEvent("result-download-completed", {
+        tabId,
+        mode: latestResult.mode,
+        filename: exportResult.filename,
+        count: items.length,
+      });
+      return {
+        type: MESSAGE_TYPES.exportResult,
+        ...exportResult,
+        mode: latestResult.mode,
+      };
+    }
+
+    case MESSAGE_TYPES.enrichmentStartRequest: {
+      if (tabId == null) {
+        return { ok: false, error: "tabId is required for enrichment" };
+      }
+
+      const state = getSerializableState(tabId);
+
       if (state.runState === RUN_STATES.running || state.runState === RUN_STATES.stopping) {
-        return {
-          ok: false,
-          error: "Stop the crawler before running enriched export.",
-        };
+        return { ok: false, error: "Stop the crawler before running enrichment." };
+      }
+
+      if (isAiValidationRunning(state)) {
+        return { ok: false, error: "Wait for AI validation to finish before running enrichment." };
       }
 
       if (!state.count) {
         return { ok: false, error: "No posts available to enrich." };
-      }
-
-      if (
-        state.enrichment?.status === ENRICHMENT_STATES.completed &&
-        state.enrichment?.readyForDownload
-      ) {
-        const enrichedItems = getEnrichedItems(tabId).map(toEnrichedExportItem);
-        const exportResult = await downloadJsonExport({
-          items: enrichedItems,
-          filename: buildExportFilename("enriched"),
-        });
-        logServiceWorkerEvent("enriched-export-completed", {
-          tabId,
-          filename: exportResult.filename,
-          count: enrichedItems.length,
-        });
-        return { type: MESSAGE_TYPES.exportResult, ...exportResult, ready: true };
       }
 
       if (activeEnrichments.has(tabId)) {
@@ -448,6 +495,50 @@ async function handleMessage(message, sender) {
       };
     }
 
+    case MESSAGE_TYPES.exportEnrichedRequest: {
+      if (tabId == null) {
+        return { ok: false, error: "tabId is required for export" };
+      }
+
+      const state = getSerializableState(tabId);
+
+      if (state.runState === RUN_STATES.running || state.runState === RUN_STATES.stopping) {
+        return {
+          ok: false,
+          error: "Stop the crawler before running enriched export.",
+        };
+      }
+
+      if (!state.count) {
+        return { ok: false, error: "No posts available to enrich." };
+      }
+
+      if (
+        state.enrichment?.status === ENRICHMENT_STATES.completed &&
+        state.enrichment?.readyForDownload
+      ) {
+        const enrichedItems = getLatestResultItems(tabId).items.map(toEnrichedExportItem);
+        const exportResult = await downloadJsonExport({
+          items: enrichedItems,
+          filename: buildExportFilename(),
+        });
+        logServiceWorkerEvent("enriched-export-completed", {
+          tabId,
+          filename: exportResult.filename,
+          count: enrichedItems.length,
+        });
+        return { type: MESSAGE_TYPES.exportResult, ...exportResult, ready: true };
+      }
+
+      return handleMessage(
+        {
+          type: MESSAGE_TYPES.enrichmentStartRequest,
+          tabId,
+        },
+        sender
+      );
+    }
+
     case MESSAGE_TYPES.exportPreviewRequest: {
       if (tabId == null) {
         return { ok: false, error: "tabId is required for preview" };
@@ -470,14 +561,14 @@ async function handleMessage(message, sender) {
 
       const items =
         mode === "enriched"
-          ? getEnrichedItems(tabId).map(toEnrichedExportItem)
+          ? getLatestResultItems(tabId).items.map(toEnrichedExportItem)
           : state.items.map(toRawExportItem);
 
       return {
         ok: true,
         mode,
         count: items.length,
-        filename: buildExportFilename(mode),
+        filename: buildExportFilename(),
         json: serializeExportItems(items),
       };
     }
@@ -591,9 +682,25 @@ async function broadcastAiActivity(tabId, text) {
   }
 }
 
-function buildExportFilename(mode, date = new Date()) {
-  const suffix = mode === "enriched" ? "_enriched" : "";
-  return `linkedin_dump_${date.toISOString().slice(0, 10)}${suffix}.json`;
+function isEnrichmentRunning(state) {
+  return state?.enrichment?.status === ENRICHMENT_STATES.running;
+}
+
+function isAiValidationRunning(state) {
+  return [AI_QUEUE_PHASES.running, AI_QUEUE_PHASES.backingOff].includes(state?.aiQueue?.phase);
+}
+
+function isProcessingLocked(state) {
+  return (
+    state?.runState === RUN_STATES.running ||
+    state?.runState === RUN_STATES.stopping ||
+    isEnrichmentRunning(state) ||
+    isAiValidationRunning(state)
+  );
+}
+
+function buildExportFilename(date = new Date()) {
+  return buildResultFilename(date);
 }
 
 function resolveTabId(message, sender) {
@@ -902,8 +1009,7 @@ async function runEnrichment(tabId) {
   activeEnrichments.set(tabId, run);
 
   try {
-    const state = getSerializableState(tabId);
-    const enrichedItems = state.items.map((item) => ({ ...item }));
+    const enrichedItems = getEnrichedItems(tabId);
     const authorBuckets = buildAuthorBuckets(enrichedItems);
 
     let processedAuthors = 0;
@@ -936,7 +1042,7 @@ async function runEnrichment(tabId) {
       processedAuthors += 1;
       processedPosts += bucket.indexes.length;
 
-      progressState = await updateEnrichmentProgress(tabId, {
+      progressState = await syncEnrichedItems(tabId, enrichedItems, {
         processedAuthors,
         processedPosts,
         currentAuthor: bucket.author,

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -70,6 +70,9 @@ import {
     crawlerCommand: "collector/crawler-command",
     crawlerProgress: "collector/crawler-progress",
     log: "collector/log",
+    downloadResultRequest: "collector/download-result-request",
+    enrichmentStartRequest: "collector/enrichment-start-request",
+    enrichmentCancelRequest: "collector/enrichment-cancel-request",
     exportRawRequest: "collector/export-raw-request",
     exportEnrichedRequest: "collector/export-enriched-request",
     exportPreviewRequest: "collector/export-preview-request",
@@ -809,16 +812,12 @@ import {
     return getAiDoneCount() > 0;
   }
 
-  function getEnrichedButtonLabel() {
+  function getEnrichmentRunButtonLabel() {
     if (uiState.enrichment.status === ENRICHMENT_STATES.running) {
-      return "Enriching...";
+      return "Enrichment running...";
     }
 
-    if (uiState.enrichment.readyForDownload) {
-      return uiState.aiCounts.pending > 0 ? "Download enriched (AI pending)" : "Download enriched";
-    }
-
-    return "Export enriched";
+    return "Run Enrichment";
   }
 
   function escapeRegExp(value) {
@@ -2172,7 +2171,8 @@ import {
         }
 
         .harvester-start,
-        .harvester-export-enriched,
+        .harvester-download-result,
+        .harvester-enrichment-run,
         .harvester-ai-run {
           background: #2563eb;
           color: #ffffff;
@@ -2180,7 +2180,7 @@ import {
         }
 
         .harvester-stop,
-        .harvester-export-raw,
+        .harvester-enrichment-cancel,
         .harvester-ai-cancel {
           background: #f8fafc;
           color: #334155;
@@ -2394,8 +2394,9 @@ import {
           </div>
           <div class="harvester-actions">
             <button class="harvester-button harvester-stop" type="button">Stop</button>
-            <button class="harvester-button harvester-export-raw" type="button">Export raw</button>
-            <button class="harvester-button harvester-export-enriched" type="button">Export enriched</button>
+            <button class="harvester-button harvester-download-result" type="button">Download Result</button>
+            <button class="harvester-button harvester-enrichment-run" type="button">Run Enrichment</button>
+            <button class="harvester-button harvester-enrichment-cancel" type="button">Cancel Enrichment</button>
             <button class="harvester-button harvester-ai-run" type="button">Run AI validation</button>
             <button class="harvester-button harvester-ai-cancel" type="button">Cancel AI validation</button>
           </div>
@@ -2472,8 +2473,9 @@ import {
       reposts: shadowRoot.querySelector(".harvester-reposts"),
       mode: shadowRoot.querySelector(".harvester-mode"),
       waitCount: shadowRoot.querySelector(".harvester-wait-count"),
-      exportRawButton: shadowRoot.querySelector(".harvester-export-raw"),
-      exportEnrichedButton: shadowRoot.querySelector(".harvester-export-enriched"),
+      downloadResultButton: shadowRoot.querySelector(".harvester-download-result"),
+      enrichmentRunButton: shadowRoot.querySelector(".harvester-enrichment-run"),
+      enrichmentCancelButton: shadowRoot.querySelector(".harvester-enrichment-cancel"),
       aiRunButton: shadowRoot.querySelector(".harvester-ai-run"),
       aiCancelButton: shadowRoot.querySelector(".harvester-ai-cancel"),
       enrichmentSummary: shadowRoot.querySelector(".harvester-enrichment-summary"),
@@ -2521,11 +2523,14 @@ import {
     panel.chip.addEventListener("click", function () {
       void setPanelMinimized(false);
     });
-    panel.exportRawButton.addEventListener("click", function () {
-      void exportCurrentBatch("raw");
+    panel.downloadResultButton.addEventListener("click", function () {
+      void downloadLatestResultFromPanel();
     });
-    panel.exportEnrichedButton.addEventListener("click", function () {
-      void exportCurrentBatch("enriched");
+    panel.enrichmentRunButton.addEventListener("click", function () {
+      void runEnrichmentFromPanel();
+    });
+    panel.enrichmentCancelButton.addEventListener("click", function () {
+      void cancelEnrichmentFromPanel();
     });
     panel.aiRunButton.addEventListener("click", function () {
       void runAiValidationFromPanel();
@@ -2566,15 +2571,12 @@ import {
       uiState.runState === RUN_STATES.unavailable;
     panel.stopButton.disabled =
       uiState.runState !== RUN_STATES.running && uiState.runState !== RUN_STATES.stopping;
-    panel.exportRawButton.disabled = uiState.runState === RUN_STATES.unavailable;
-    panel.exportEnrichedButton.disabled =
-      uiState.runState === RUN_STATES.running ||
-      uiState.runState === RUN_STATES.stopping ||
-      uiState.runState === RUN_STATES.unavailable ||
-      uiState.enrichment.status === ENRICHMENT_STATES.running;
+    panel.downloadResultButton.disabled = !canDownloadResult();
+    panel.enrichmentRunButton.disabled = !canRunEnrichment();
+    panel.enrichmentCancelButton.disabled = !isEnrichmentRunning();
     panel.aiRunButton.disabled = !canRunAiValidation();
     panel.aiCancelButton.disabled = !isAiValidationRunning();
-    panel.exportEnrichedButton.textContent = getEnrichedButtonLabel();
+    panel.enrichmentRunButton.textContent = getEnrichmentRunButtonLabel();
     panel.aiRunButton.textContent = getAiRunButtonLabel();
     panel.heroCount.textContent = String(uiState.count);
     panel.heroTarget.textContent = String(uiState.targetCount);
@@ -2639,48 +2641,41 @@ import {
     panel.shell.style.width = uiState.panelMinimized ? "164px" : "320px";
   }
 
-  async function exportCurrentBatch(mode) {
-    if (!panel || !isExtensionContextAvailable()) {
-      return;
-    }
+  function canDownloadResult() {
+    return (
+      uiState.count > 0 &&
+      uiState.runState !== RUN_STATES.running &&
+      uiState.runState !== RUN_STATES.stopping &&
+      uiState.runState !== RUN_STATES.unavailable &&
+      !isEnrichmentRunning() &&
+      !isAiValidationRunning()
+    );
+  }
 
-    const isEnriched = mode === "enriched";
-    const button = isEnriched ? panel.exportEnrichedButton : panel.exportRawButton;
-    button.disabled = true;
-    pushActivity(isEnriched ? "Enriched export requested." : "Raw export requested.");
-
-    try {
-      const response = await safeSendMessage({
-        type: isEnriched ? MESSAGE_TYPES.exportEnrichedRequest : MESSAGE_TYPES.exportRawRequest,
-      });
-
-      if (!response?.ok) {
-        throw new Error(response?.error || "Export failed");
-      }
-
-      if (response?.filename) {
-        pushActivity("Downloaded " + response.filename);
-      } else if (isEnriched) {
-        pushActivity("Author enrichment started.");
-      }
-    } catch (error) {
-      pushActivity(error.message);
-    } finally {
-      button.disabled = false;
-      renderPanel();
-    }
+  function canRunEnrichment() {
+    return (
+      uiState.count > 0 &&
+      uiState.runState !== RUN_STATES.running &&
+      uiState.runState !== RUN_STATES.stopping &&
+      uiState.runState !== RUN_STATES.unavailable &&
+      !isEnrichmentRunning() &&
+      !isAiValidationRunning()
+    );
   }
 
   function canRunAiValidation() {
-    const hasEligiblePosts =
-      (uiState.aiCounts.pending || 0) > 0 || (uiState.aiCounts.unknown || 0) > 0;
-
     return (
-      hasEligiblePosts &&
+      uiState.count > 0 &&
       uiState.runState !== RUN_STATES.running &&
       uiState.runState !== RUN_STATES.stopping &&
+      uiState.runState !== RUN_STATES.unavailable &&
+      !isEnrichmentRunning() &&
       !isAiValidationRunning()
     );
+  }
+
+  function isEnrichmentRunning() {
+    return uiState.enrichment.status === ENRICHMENT_STATES.running;
   }
 
   function isAiValidationRunning() {
@@ -2700,6 +2695,82 @@ import {
     }
 
     return "Run AI validation";
+  }
+
+  async function downloadLatestResultFromPanel() {
+    if (!panel || !isExtensionContextAvailable()) {
+      return;
+    }
+
+    panel.downloadResultButton.disabled = true;
+    pushActivity("Result download requested.");
+    renderPanel();
+
+    try {
+      const response = await safeSendMessage({
+        type: MESSAGE_TYPES.downloadResultRequest,
+      });
+
+      if (!response?.ok) {
+        throw new Error(response?.error || "Failed to download result.");
+      }
+
+      pushActivity("Downloaded " + response.filename);
+    } catch (error) {
+      pushActivity(error.message);
+    } finally {
+      renderPanel();
+    }
+  }
+
+  async function runEnrichmentFromPanel() {
+    if (!panel || !isExtensionContextAvailable()) {
+      return;
+    }
+
+    panel.enrichmentRunButton.disabled = true;
+    pushActivity("Enrichment requested.");
+    renderPanel();
+
+    try {
+      const response = await safeSendMessage({
+        type: MESSAGE_TYPES.enrichmentStartRequest,
+      });
+
+      if (!response?.ok) {
+        throw new Error(response?.error || "Failed to start enrichment.");
+      }
+
+      pushActivity("Enrichment started.");
+    } catch (error) {
+      pushActivity(error.message);
+    } finally {
+      renderPanel();
+    }
+  }
+
+  async function cancelEnrichmentFromPanel() {
+    if (!panel || !isExtensionContextAvailable()) {
+      return;
+    }
+
+    panel.enrichmentCancelButton.disabled = true;
+    pushActivity("Enrichment cancellation requested.");
+    renderPanel();
+
+    try {
+      const response = await safeSendMessage({
+        type: MESSAGE_TYPES.enrichmentCancelRequest,
+      });
+
+      if (!response?.ok) {
+        throw new Error(response?.error || "Failed to cancel enrichment.");
+      }
+    } catch (error) {
+      pushActivity(error.message);
+    } finally {
+      renderPanel();
+    }
   }
 
   async function runAiValidationFromPanel() {

--- a/src/shared/author-weight.js
+++ b/src/shared/author-weight.js
@@ -2,6 +2,7 @@ export const AUTHOR_WEIGHT = {
   high: "high",
   medium: "medium",
   low: "low",
+  trivial: "trivial",
 };
 
 const HIGH_ROLE_PATTERNS = [
@@ -100,21 +101,27 @@ export function classifyAuthorWeight({ role, followers } = {}) {
   const normalizedRole = String(role || "").trim();
   const normalizedFollowers = parseFollowerCount(followers);
 
-  if (
-    HIGH_ROLE_PATTERNS.some((pattern) => pattern.test(normalizedRole)) ||
-    normalizedFollowers >= 10000
-  ) {
+  if (normalizedFollowers != null) {
+    if (normalizedFollowers >= 10000) {
+      return AUTHOR_WEIGHT.high;
+    }
+
+    if (normalizedFollowers >= 2000) {
+      return AUTHOR_WEIGHT.medium;
+    }
+
+    return AUTHOR_WEIGHT.low;
+  }
+
+  if (HIGH_ROLE_PATTERNS.some((pattern) => pattern.test(normalizedRole))) {
     return AUTHOR_WEIGHT.high;
   }
 
-  if (
-    MEDIUM_ROLE_PATTERNS.some((pattern) => pattern.test(normalizedRole)) ||
-    normalizedFollowers >= 2000
-  ) {
+  if (MEDIUM_ROLE_PATTERNS.some((pattern) => pattern.test(normalizedRole))) {
     return AUTHOR_WEIGHT.medium;
   }
 
-  return AUTHOR_WEIGHT.low;
+  return AUTHOR_WEIGHT.trivial;
 }
 
 export function buildAuthorSignalPatch(authorData = {}) {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -76,6 +76,8 @@ export const MESSAGE_TYPES = {
   crawlerCommand: "collector/crawler-command",
   crawlerProgress: "collector/crawler-progress",
   log: "collector/log",
+  downloadResultRequest: "collector/download-result-request",
+  enrichmentStartRequest: "collector/enrichment-start-request",
   exportRawRequest: "collector/export-raw-request",
   exportEnrichedRequest: "collector/export-enriched-request",
   exportPreviewRequest: "collector/export-preview-request",

--- a/src/shared/export.js
+++ b/src/shared/export.js
@@ -22,10 +22,29 @@ export function toEnrichedExportItem(item) {
     ...pickExportFields(item),
     author_role: item?.author_role || null,
     author_followers: typeof item?.author_followers === "number" ? item.author_followers : null,
-    author_weight: item?.author_weight || "low",
+    author_weight: item?.author_weight || "trivial",
   };
 }
 
 export function serializeExportItems(items) {
   return JSON.stringify(items, null, 2);
+}
+
+function padDatePart(value) {
+  return String(value).padStart(2, "0");
+}
+
+export function buildResultFilename(date = new Date()) {
+  const timestamp = [
+    date.getFullYear(),
+    padDatePart(date.getMonth() + 1),
+    padDatePart(date.getDate()),
+  ].join("");
+  const time = [
+    padDatePart(date.getHours()),
+    padDatePart(date.getMinutes()),
+    padDatePart(date.getSeconds()),
+  ].join("");
+
+  return `linkedin_crawl_result_${timestamp}-${time}.json`;
 }

--- a/src/shared/panel.js
+++ b/src/shared/panel.js
@@ -91,8 +91,9 @@ export function createPanelMarkup() {
         </div>
         <div class="harvester-actions">
           <button class="harvester-button harvester-stop" type="button">Stop</button>
-          <button class="harvester-button harvester-export-raw" type="button">Export raw</button>
-          <button class="harvester-button harvester-export-enriched" type="button">Export enriched</button>
+          <button class="harvester-button harvester-download-result" type="button">Download Result</button>
+          <button class="harvester-button harvester-enrichment-run" type="button">Run Enrichment</button>
+          <button class="harvester-button harvester-enrichment-cancel" type="button">Cancel Enrichment</button>
           <button class="harvester-button harvester-ai-run" type="button">Run AI validation</button>
           <button class="harvester-button harvester-ai-cancel" type="button">Cancel AI validation</button>
         </div>

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -82,10 +82,33 @@ function buildFallbackFingerprint(item) {
   return `${item.author.toLowerCase()}::${item.extracted_at}`;
 }
 
+function stripFingerprint(item) {
+  const { fingerprint, ...nextItem } = item || {};
+  return nextItem;
+}
+
+function cloneItems(items = []) {
+  return items.map((item) => ({ ...item }));
+}
+
+function getItemsWithFingerprint(tabState) {
+  return Array.from(tabState.itemsByFingerprint.values()).map((item) => ({ ...item }));
+}
+
+function getInterestValidationForItem(tabState, item) {
+  const fingerprint = item?.fingerprint || buildFallbackFingerprint(item);
+
+  if (fingerprint && tabState.itemsByFingerprint.has(fingerprint)) {
+    return tabState.itemsByFingerprint.get(fingerprint).interest_validation;
+  }
+
+  return item?.interest_validation || createPendingInterestValidation();
+}
+
 export function getSerializableState(tabId) {
   const tabState = getOrCreateTabState(tabId);
-  const itemsWithFingerprint = Array.from(tabState.itemsByFingerprint.values());
-  const items = itemsWithFingerprint.map(({ fingerprint, ...item }) => item);
+  const itemsWithFingerprint = getItemsWithFingerprint(tabState);
+  const items = itemsWithFingerprint.map(stripFingerprint);
   const aiCounts = getAiCounts(itemsWithFingerprint);
 
   return {
@@ -99,7 +122,7 @@ export function getSerializableState(tabId) {
     noProgressCycles: tabState.noProgressCycles,
     stalledWaitCount: tabState.stalledWaitCount,
     lastReason: tabState.lastReason,
-    enrichedItems: tabState.enrichedItems.map(({ fingerprint, ...item }) => item),
+    enrichedItems: tabState.enrichedItems.map(stripFingerprint),
     enrichment: { ...tabState.enrichment },
     aiCounts,
     aiQueue: { ...tabState.aiQueue, pendingCount: aiCounts.pending },
@@ -107,9 +130,23 @@ export function getSerializableState(tabId) {
 }
 
 export function getExportItems(tabId) {
-  return Array.from(getOrCreateTabState(tabId).itemsByFingerprint.values()).map(
-    ({ fingerprint, ...item }) => item
-  );
+  return getItemsWithFingerprint(getOrCreateTabState(tabId)).map(stripFingerprint);
+}
+
+export function getLatestResultItems(tabId) {
+  const tabState = getOrCreateTabState(tabId);
+  const hasEnrichedSnapshot = tabState.enrichedItems.length > 0;
+  const sourceItems = hasEnrichedSnapshot
+    ? tabState.enrichedItems
+    : getItemsWithFingerprint(tabState);
+
+  return {
+    mode: hasEnrichedSnapshot ? "enriched" : "raw",
+    items: sourceItems.map((item) => ({
+      ...item,
+      interest_validation: getInterestValidationForItem(tabState, item),
+    })),
+  };
 }
 
 export function markStatus(tabId, status) {
@@ -269,6 +306,19 @@ export function getAiValidationEligibleItems(tabId) {
   );
 }
 
+export function resetAiValidationStatuses(tabId) {
+  const tabState = getOrCreateTabState(tabId);
+
+  for (const [fingerprint, item] of tabState.itemsByFingerprint.entries()) {
+    tabState.itemsByFingerprint.set(fingerprint, {
+      ...item,
+      interest_validation: createPendingInterestValidation(),
+    });
+  }
+
+  return persistState(tabId);
+}
+
 export function updateInterestValidation(tabId, fingerprint, validationPatch) {
   const tabState = getOrCreateTabState(tabId);
   const currentItem = tabState.itemsByFingerprint.get(fingerprint);
@@ -327,10 +377,11 @@ export function startEnrichment(
   { totalPosts = 0, totalAuthors = 0, lastMessage = null } = {}
 ) {
   const tabState = getOrCreateTabState(tabId);
-  tabState.enrichedItems = [];
+  const baseItems = getItemsWithFingerprint(tabState);
+  tabState.enrichedItems = cloneItems(baseItems);
   tabState.enrichment = {
     status: ENRICHMENT_STATES.running,
-    totalPosts,
+    totalPosts: totalPosts || baseItems.length,
     processedPosts: 0,
     totalAuthors,
     processedAuthors: 0,
@@ -353,11 +404,21 @@ export function updateEnrichmentProgress(tabId, patch = {}) {
   return persistState(tabId);
 }
 
+export function syncEnrichedItems(tabId, enrichedItems, patch = {}) {
+  const tabState = getOrCreateTabState(tabId);
+  tabState.enrichedItems = cloneItems(enrichedItems);
+  tabState.enrichment = {
+    ...tabState.enrichment,
+    ...patch,
+    status: ENRICHMENT_STATES.running,
+    readyForDownload: false,
+  };
+  return persistState(tabId);
+}
+
 export function completeEnrichment(tabId, enrichedItems, lastMessage) {
   const tabState = getOrCreateTabState(tabId);
-  tabState.enrichedItems = Array.isArray(enrichedItems)
-    ? enrichedItems.map((item) => ({ ...item }))
-    : [];
+  tabState.enrichedItems = Array.isArray(enrichedItems) ? cloneItems(enrichedItems) : [];
   tabState.enrichment = {
     ...tabState.enrichment,
     status: ENRICHMENT_STATES.completed,
@@ -373,7 +434,6 @@ export function completeEnrichment(tabId, enrichedItems, lastMessage) {
 
 export function failEnrichment(tabId, lastMessage) {
   const tabState = getOrCreateTabState(tabId);
-  tabState.enrichedItems = [];
   tabState.enrichment = {
     ...tabState.enrichment,
     status: ENRICHMENT_STATES.failed,
@@ -386,7 +446,6 @@ export function failEnrichment(tabId, lastMessage) {
 
 export function cancelEnrichment(tabId, lastMessage) {
   const tabState = getOrCreateTabState(tabId);
-  tabState.enrichedItems = [];
   tabState.enrichment = {
     ...tabState.enrichment,
     status: ENRICHMENT_STATES.cancelled,
@@ -398,7 +457,7 @@ export function cancelEnrichment(tabId, lastMessage) {
 }
 
 export function getEnrichedItems(tabId) {
-  return getOrCreateTabState(tabId).enrichedItems.map((item) => ({ ...item }));
+  return cloneItems(getOrCreateTabState(tabId).enrichedItems);
 }
 
 export async function persistState(tabId) {
@@ -431,7 +490,10 @@ export async function hydrateStateFromStorage(tabId) {
   }
 
   tabState.enrichedItems = Array.isArray(storedState?.enrichedItems)
-    ? storedState.enrichedItems.map((item) => ({ ...item }))
+    ? storedState.enrichedItems.map((item) => ({
+        ...item,
+        fingerprint: item?.fingerprint || buildFallbackFingerprint(item),
+      }))
     : [];
 
   tabState.ignoredSamples = Array.isArray(storedState?.ignoredSamples)

--- a/test/author-weight.smoke.test.js
+++ b/test/author-weight.smoke.test.js
@@ -32,18 +32,34 @@ describe("author weight helpers", () => {
   });
 
   it("classifies high-weight authors from role or followers", () => {
-    expect(classifyAuthorWeight({ role: "CEO at Example", followers: 500 })).toBe(
+    expect(classifyAuthorWeight({ role: "Engineer", followers: 20000 })).toBe(AUTHOR_WEIGHT.high);
+    expect(classifyAuthorWeight({ role: "CEO at Example", followers: null })).toBe(
       AUTHOR_WEIGHT.high
     );
-    expect(classifyAuthorWeight({ role: "Engineer", followers: 20000 })).toBe(AUTHOR_WEIGHT.high);
   });
 
   it("classifies medium and low-weight authors deterministically", () => {
-    expect(classifyAuthorWeight({ role: "Engineering Director", followers: 900 })).toBe(
+    expect(classifyAuthorWeight({ role: "Engineering Director", followers: null })).toBe(
       AUTHOR_WEIGHT.medium
     );
     expect(classifyAuthorWeight({ role: "Software Engineer", followers: 400 })).toBe(
       AUTHOR_WEIGHT.low
+    );
+  });
+
+  it("classifies missing or weak signals as trivial when followers are absent", () => {
+    expect(classifyAuthorWeight({ role: null, followers: null })).toBe(AUTHOR_WEIGHT.trivial);
+    expect(classifyAuthorWeight({ role: "Software Engineer", followers: null })).toBe(
+      AUTHOR_WEIGHT.trivial
+    );
+  });
+
+  it("keeps strong role fallback when followers are absent", () => {
+    expect(classifyAuthorWeight({ role: "CEO at Example", followers: null })).toBe(
+      AUTHOR_WEIGHT.high
+    );
+    expect(classifyAuthorWeight({ role: "Engineering Director", followers: null })).toBe(
+      AUTHOR_WEIGHT.medium
     );
   });
 
@@ -57,6 +73,19 @@ describe("author weight helpers", () => {
       author_role: "CTO",
       author_followers: 11000,
       author_weight: AUTHOR_WEIGHT.high,
+    });
+  });
+
+  it("builds a trivial signal patch when enrichment has no useful signals", () => {
+    expect(
+      buildAuthorSignalPatch({
+        role: null,
+        followers: null,
+      })
+    ).toEqual({
+      author_role: null,
+      author_followers: null,
+      author_weight: AUTHOR_WEIGHT.trivial,
     });
   });
 });

--- a/test/export.smoke.test.js
+++ b/test/export.smoke.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildResultFilename,
   serializeExportItems,
   toEnrichedExportItem,
   toRawExportItem,
@@ -36,5 +37,23 @@ describe("export helpers", () => {
     expect(json).toContain('"author_role": "Engineer"');
     expect(json).toContain('"author_followers": 1200');
     expect(json).toContain('"author_weight": "high"');
+  });
+
+  it("defaults enriched author_weight to trivial when signals are missing", () => {
+    const json = serializeExportItems([
+      toEnrichedExportItem({
+        author: "Ada Lovelace",
+        author_role: null,
+        author_followers: null,
+      }),
+    ]);
+
+    expect(json).toContain('"author_weight": "trivial"');
+  });
+
+  it("builds result filenames with local datetime precision", () => {
+    expect(buildResultFilename(new Date(2026, 3, 5, 9, 7, 3))).toBe(
+      "linkedin_crawl_result_20260405-090703.json"
+    );
   });
 });

--- a/test/panel.smoke.test.js
+++ b/test/panel.smoke.test.js
@@ -39,8 +39,9 @@ describe("floating panel helpers", () => {
     const markup = createPanelMarkup();
 
     expect(markup).toContain("harvester-header");
-    expect(markup).toContain("harvester-export-raw");
-    expect(markup).toContain("harvester-export-enriched");
+    expect(markup).toContain("harvester-download-result");
+    expect(markup).toContain("harvester-enrichment-run");
+    expect(markup).toContain("harvester-enrichment-cancel");
     expect(markup).toContain("harvester-ai-run");
     expect(markup).toContain("harvester-ai-cancel");
     expect(markup).toContain("harvester-start");

--- a/test/state.smoke.test.js
+++ b/test/state.smoke.test.js
@@ -2,9 +2,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendIgnoredSamples,
   getAiValidationEligibleItems,
+  getLatestResultItems,
   getSerializableState,
+  hydrateStateFromStorage,
+  resetAiValidationStatuses,
   resetDebugState,
   setAiQueueState,
+  startEnrichment,
+  syncEnrichedItems,
   updateInterestValidationBatch,
 } from "../src/shared/state.js";
 
@@ -47,7 +52,7 @@ describe("tab state debug samples", () => {
     expect(state.ignoredSamples[49].reason).toBe("reason-2");
   });
 
-  it("targets only pending and unknown posts for AI reruns", async () => {
+  it("targets only pending and unknown posts for queue processing", async () => {
     mockChromeStorage();
 
     await resetDebugState(52);
@@ -101,17 +106,65 @@ describe("tab state debug samples", () => {
       },
     });
 
-    const { hydrateStateFromStorage } = await import("../src/shared/state.js");
     await hydrateStateFromStorage(52);
 
     const eligible = getAiValidationEligibleItems(52);
     expect(eligible.map((item) => item.fingerprint)).toEqual(["fp-pending", "fp-unknown"]);
   });
 
+  it("resets AI validation to pending for all posts on rerun", async () => {
+    mockChromeStorage();
+
+    globalThis.chrome.storage.session.get.mockResolvedValue({
+      "collector.tab.54": {
+        items: [
+          {
+            fingerprint: "fp-interested",
+            author: "Ada",
+            extracted_at: "2026-03-30T10:00:00.000Z",
+            interest_validation: {
+              status: "interested",
+              attempts: 1,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: null,
+              source: "gemini",
+            },
+          },
+          {
+            fingerprint: "fp-not",
+            author: "Grace",
+            extracted_at: "2026-03-30T10:01:00.000Z",
+            interest_validation: {
+              status: "not_interested",
+              attempts: 1,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: null,
+              source: "gemini",
+            },
+          },
+        ],
+      },
+    });
+
+    await hydrateStateFromStorage(54);
+    await resetAiValidationStatuses(54);
+
+    const state = getSerializableState(54);
+    expect(state.aiCounts).toEqual({
+      pending: 2,
+      interested: 0,
+      not_interested: 0,
+      unknown: 0,
+    });
+    expect(getAiValidationEligibleItems(54).map((item) => item.fingerprint)).toEqual([
+      "fp-interested",
+      "fp-not",
+    ]);
+  });
+
   it("persists bulk AI queue progress and batch validation patches", async () => {
     mockChromeStorage();
 
-    const { hydrateStateFromStorage } = await import("../src/shared/state.js");
     globalThis.chrome.storage.session.get.mockResolvedValue({
       "collector.tab.53": {
         items: [
@@ -189,6 +242,71 @@ describe("tab state debug samples", () => {
       interested: 1,
       not_interested: 1,
       unknown: 0,
+    });
+  });
+
+  it("composes the latest enriched snapshot with AI validation from raw state", async () => {
+    mockChromeStorage();
+
+    globalThis.chrome.storage.session.get.mockResolvedValue({
+      "collector.tab.55": {
+        items: [
+          {
+            fingerprint: "fp-1",
+            author: "Ada",
+            extracted_at: "2026-03-30T10:00:00.000Z",
+            author_profile_url: "https://www.linkedin.com/in/ada/",
+            interest_validation: {
+              status: "interested",
+              attempts: 1,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: null,
+              source: "gemini",
+            },
+          },
+        ],
+      },
+    });
+
+    await hydrateStateFromStorage(55);
+    await startEnrichment(55, {
+      totalPosts: 1,
+      totalAuthors: 1,
+      lastMessage: "Starting author enrichment.",
+    });
+    await syncEnrichedItems(
+      55,
+      [
+        {
+          fingerprint: "fp-1",
+          author: "Ada",
+          extracted_at: "2026-03-30T10:00:00.000Z",
+          author_profile_url: "https://www.linkedin.com/in/ada/",
+          author_role: "Engineer",
+          author_followers: 1200,
+          author_weight: "low",
+        },
+      ],
+      {
+        processedPosts: 1,
+        processedAuthors: 1,
+        currentAuthor: "Ada",
+        currentPostIndex: 1,
+        lastMessage: "Cache hit for Ada.",
+      }
+    );
+
+    const latest = getLatestResultItems(55);
+
+    expect(latest.mode).toBe("enriched");
+    expect(latest.items).toHaveLength(1);
+    expect(latest.items[0]).toMatchObject({
+      author_role: "Engineer",
+      author_followers: 1200,
+      author_weight: "low",
+    });
+    expect(latest.items[0].interest_validation).toMatchObject({
+      status: "interested",
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace the LinkedIn panel export/enrichment UX with explicit Download Result, Run Enrichment, and Cancel Enrichment actions
- compose the latest stable result snapshot from raw items, enrichment data, and AI validation so reruns preserve completed work
- switch result downloads to a local timestamped filename and align docs/tests with the new flow

## Testing
- npm run format:write
- npm run lint
- npm test
- npm run build
- npm run prepush

## Follow-ups
- #27
- #28
- #29