### PR TITLE
Improve AI default prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Author enrichment cache for BL-002 is persisted in `chrome.storage.local` so rep
 - Enriched exports may classify authors as `trivial` when enrichment does not find followers or a strong enough role signal to support a meaningful priority
 - Optionally enrich each captured post with `interest_validation` using Gemini AI Studio
 - Run AI validation manually after capture in fixed chunks, with retry/backoff on quota and rate pressure
+- The default AI validation prompt rejects posts whose dominant goal is sales, PR, upsell, demo booking, offers, lead generation, product or feature launches, or commercial CTAs
+- Custom Gemini prompts saved by the user are preserved; only the previous built-in default prompt migrates silently to the current default
 
 ## Expected Workflow
 

--- a/src/background/default-system-instruction.js
+++ b/src/background/default-system-instruction.js
@@ -1,7 +1,25 @@
-export const DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts para un perfil profesional que quiere comentar donde pueda aportar una observacion util, estrategica o experta.
+export const LEGACY_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts para un perfil profesional que quiere comentar donde pueda aportar una observacion util, estrategica o experta.
 
 Prioriza contenido con sustancia, opinion, aprendizaje, industria, liderazgo, tecnologia, negocio o temas donde un comentario bien pensado agregaria valor.
 
 Marca como not_interested el contenido vacio, demasiado personal, celebratorio sin contenido, engagement bait, autopromocion obvia o posts sin un angulo claro para comentar.
+
+Si hay duda, responde not_interested.`;
+
+export const DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts de LinkedIn para un perfil profesional que quiere comentar solo donde pueda aportar una observacion util, estrategica o experta y conectar con profesionales valiosos y sus audiencias.
+
+Marca como interested cuando el objetivo dominante sea una conversacion profesional con sustancia: experiencia personal con aprendizaje transferible, analisis independiente, opinion fundada, liderazgo, tecnologia, industria, negocio o decisiones donde un comentario experto agregaria valor.
+
+Marca como not_interested cuando el objetivo dominante sea vender, promocionar, anunciar, generar leads, pedir demos, ofrecer productos o servicios, pedir contacto, empujar una conversion comercial o llevar trafico a una oferta.
+
+Tambien marca como not_interested el PR comercial, lanzamientos de producto o feature, anuncios de empresa, upsells, ofertas, webinars o eventos usados como lead-gen, casos de exito usados para vender y CTAs como book a call, request demo, contact us, compra, registrate o agenda una llamada.
+
+Si un post comercial contiene algun insight util pero sigue principalmente promocionando una empresa, producto, servicio, oferta o accion comercial, responde not_interested.
+
+No descartes automaticamente un post solo porque menciona una empresa o producto como contexto; si no busca vender y aporta analisis independiente o aprendizaje transferible, puede ser interested.
+
+Ejemplos interested: historia propia con aprendizaje general sin venta directa; analisis de una decision tecnica o de negocio; opinion profesional sobre una tendencia con sustancia.
+
+Ejemplos not_interested: lanzamiento de producto o feature; invitacion a demo o llamada; promocion de servicio, oferta, webinar lead-gen o caso de exito comercial; post con CTA comercial claro.
 
 Si hay duda, responde not_interested.`;

--- a/src/background/gemini.js
+++ b/src/background/gemini.js
@@ -1,4 +1,5 @@
 import { AI_DEFAULT_CONFIG, AI_RATE_LIMIT, AI_STATUS, STORAGE_KEYS } from "../shared/constants.js";
+import { LEGACY_GEMINI_SYSTEM_INSTRUCTION } from "./default-system-instruction.js";
 
 const GEMINI_API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -18,14 +19,37 @@ export async function saveAiConfig(configPatch) {
 }
 
 export function normalizeAiConfig(config) {
+  const systemInstruction = normalizeSystemInstruction(config?.systemInstruction);
+
   return {
     enabled: Boolean(config?.enabled),
     apiKey: String(config?.apiKey || "").trim(),
     model: String(config?.model || AI_DEFAULT_CONFIG.model).trim(),
-    systemInstruction: String(
-      config?.systemInstruction || AI_DEFAULT_CONFIG.systemInstruction
-    ).trim(),
+    systemInstruction,
   };
+}
+
+function normalizeSystemInstruction(systemInstruction) {
+  const trimmedInstruction = String(systemInstruction || "").trim();
+
+  if (!trimmedInstruction) {
+    return AI_DEFAULT_CONFIG.systemInstruction;
+  }
+
+  if (
+    normalizeInstructionForComparison(trimmedInstruction) ===
+    normalizeInstructionForComparison(LEGACY_GEMINI_SYSTEM_INSTRUCTION)
+  ) {
+    return AI_DEFAULT_CONFIG.systemInstruction;
+  }
+
+  return trimmedInstruction;
+}
+
+function normalizeInstructionForComparison(systemInstruction) {
+  return String(systemInstruction || "")
+    .replace(/\r\n/g, "\n")
+    .trim();
 }
 
 export function getAiConfigError(config) {

--- a/test/gemini.smoke.test.js
+++ b/test/gemini.smoke.test.js
@@ -8,7 +8,10 @@ import {
   validatePostsInterestBulk,
   validatePostInterest,
 } from "../src/background/gemini.js";
-import { DEFAULT_GEMINI_SYSTEM_INSTRUCTION } from "../src/background/default-system-instruction.js";
+import {
+  DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
+  LEGACY_GEMINI_SYSTEM_INSTRUCTION,
+} from "../src/background/default-system-instruction.js";
 import { AI_RATE_LIMIT, AI_STATUS } from "../src/shared/constants.js";
 
 describe("gemini validation helpers", () => {
@@ -44,6 +47,39 @@ describe("gemini validation helpers", () => {
 
     expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
     expect(getAiConfigError(config)).toBeNull();
+  });
+
+  it("uses the new default system instruction for empty config", () => {
+    expect(normalizeAiConfig().systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
+  });
+
+  it("keeps explicit anti-sales and anti-PR criteria in the default prompt", () => {
+    const prompt = DEFAULT_GEMINI_SYSTEM_INSTRUCTION.toLowerCase();
+
+    expect(prompt).toContain("vender");
+    expect(prompt).toContain("pr comercial");
+    expect(prompt).toContain("demo");
+    expect(prompt).toContain("lead-gen");
+    expect(prompt).toContain("oferta");
+    expect(prompt).toContain("lanzamiento");
+    expect(prompt).toContain("cta");
+  });
+
+  it("migrates the exact legacy default system instruction to the new default", () => {
+    const config = normalizeAiConfig({
+      systemInstruction: `\r\n${LEGACY_GEMINI_SYSTEM_INSTRUCTION.replace(/\n/g, "\r\n")}\r\n`,
+    });
+
+    expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
+  });
+
+  it("preserves custom system instructions instead of overwriting them", () => {
+    const customInstruction = `${LEGACY_GEMINI_SYSTEM_INSTRUCTION}\n\nCustom scoring note.`;
+    const config = normalizeAiConfig({
+      systemInstruction: customInstruction,
+    });
+
+    expect(config.systemInstruction).toBe(customInstruction);
   });
 
   it("parses an interested decision from Gemini", async () => {
@@ -186,6 +222,13 @@ describe("gemini validation helpers", () => {
 
     expect(result.interestedIds).toEqual(["fp-1", "fp-3"]);
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const requestBody = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    const userText = requestBody.contents[0].parts[0].text;
+
+    expect(requestBody.generationConfig.responseMimeType).toBe("application/json");
+    expect(userText).toContain('Return valid JSON only in this exact shape: {"interested_ids"');
+    expect(userText).toContain("Do not include explanations, markdown, or extra keys.");
   });
 
   it("rejects invalid bulk payloads as parse errors", async () => {


### PR DESCRIPTION
## Summary
- tighten the default Gemini prompt to classify sales, PR, demos, lead-gen, offers, launches, and commercial CTAs as not_interested
- migrate saved configs that exactly match the previous built-in default to the new default
- preserve custom user prompts and keep the bulk interested_ids response contract unchanged
- document the anti-commercial default behavior in README

## Validation
- npm run format
- npm run lint
- npm test
- npm run build
- npm run prepush

Closes #34