### PR TITLE
Improve collection output and AI validation handling

### DIFF
--- a/CODEX_PROJECT.md
+++ b/CODEX_PROJECT.md
@@ -92,12 +92,18 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
   - `is_repost`
   - `type`
   - `extracted_at`
+  - `comment_count`
+  - `comment_count_text`
+  - `reaction_count`
+  - `reaction_count_text`
 - The enriched export extends each item with:
   - `author_role`
   - `author_followers`
   - `author_weight`
 - `author_weight` in enriched exports may be `high`, `medium`, `low`, or `trivial`; `trivial` means enrichment did not find enough follower or role evidence to assign a meaningful importance signal.
+- Author enrichment must not persist cache entries when both role and followers are empty; those authors should remain retryable on future enrichment runs while the current export still reflects the observed empty signals.
 - AI validation may also persist an `interest_validation` block on each item for raw and enriched export flows.
+- Retryable Gemini failures that exhaust attempts should use `interest_validation.status = "unresolved"` with retry metadata instead of being counted as completed `unknown` classifications.
 - Author enrichment and AI validation are separate sequential passes. They share the same tab-scoped dataset and the final download composes the latest enrichment snapshot with the latest AI validation overlay.
 - The requirements file contains the typo `is_repot`; the documented repository contract should use `is_repost`.
 - `type` should remain compatible with the current MVP expectation of organic content that passed the exclusion filters.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Chrome/Brave extension project for harvesting raw LinkedIn feed posts, filtering
 This repo is intentionally documented as a browser extension, not as a backend worker. The current phase focuses on user-triggered LinkedIn crawling, noise filtering, human-like scrolling, tab-scoped collection state, and final export. It does not send emails, post comments, or sync to external APIs.
 
 Collected post batches are scoped to the current browser tab/session. Persistent local storage is reserved for lightweight UI preferences such as the floating panel position.
-Author enrichment cache for BL-002 is persisted in `chrome.storage.local` so repeated authors do not require opening their profile again on later runs.
+Author enrichment cache for BL-002 is persisted in `chrome.storage.local` only when at least one useful author signal is found, so empty transient resolutions can be retried on later runs.
 
 ## MVP Behavior
 
-- Extract `author`, `reposted_by`, `post_text`, `posted_time`, `link`, `is_repost`, `type`, and `extracted_at` from eligible feed posts
+- Extract `author`, `reposted_by`, `post_text`, `posted_time`, `link`, `is_repost`, `type`, `extracted_at`, and visible engagement snapshots from eligible feed posts
 - Read `post_text` from LinkedIn's preloaded expandable text box when present, without clicking `more`
 - Preserve LinkedIn's relative post age in `posted_time` when a clear value such as `4h` or `2w` is present
 - Start and stop crawling explicitly from the floating panel or popup instead of auto-collecting on feed load
@@ -33,8 +33,10 @@ Author enrichment cache for BL-002 is persisted in `chrome.storage.local` so rep
 - Run author enrichment and AI validation as separate manual passes from the LinkedIn panel, each with explicit `Run` and `Cancel` controls
 - Enrich author metadata with `author_role`, `author_followers`, and `author_weight`
 - Enriched exports may classify authors as `trivial` when enrichment does not find followers or a strong enough role signal to support a meaningful priority
+- Author enrichment skips cache writes when both role and followers are missing, logs that no cacheable signals were found, and retries that author in future enrichment runs
 - Optionally enrich each captured post with `interest_validation` using Gemini AI Studio
-- Run AI validation manually after capture in fixed chunks, with retry/backoff on quota and rate pressure
+- Run AI validation manually after capture in fixed sequential chunks, with retry/backoff on quota and rate pressure
+- Provider overload or other retryable failures that exhaust attempts are exported as `interest_validation.status: "unresolved"` instead of counted as a completed classification
 - The default AI validation prompt rejects posts whose dominant goal is sales, PR, upsell, demo booking, offers, lead generation, product or feature launches, or commercial CTAs
 - Custom Gemini prompts saved by the user are preserved; only the previous built-in default prompt migrates silently to the current default
 

--- a/docs/diagrams/collection-flow.md
+++ b/docs/diagrams/collection-flow.md
@@ -18,12 +18,18 @@ flowchart TD
     M --> N[Reuse local author cache]
     N --> O[Open one LinkedIn profile tab at a time]
     O --> P[Extract role and followers]
-    P --> Q[Classify author weight]
-    Q --> R[Persist enrichment snapshot]
+    P --> Q{Cacheable role or followers?}
+    Q -->|Yes| R[Update author cache]
+    Q -->|No| R2[Skip cache and log retry]
+    R --> R3[Classify author weight]
+    R2 --> R3
+    R3 --> R4[Persist enrichment snapshot]
     K --> S[User triggers AI validation]
-    R --> S
+    R4 --> S
     S --> T[Reset items to pending and send chunked Gemini bulk request]
-    T --> U[Persist interest_validation]
+    T --> T2{Chunk retryable?}
+    T2 -->|Backoff| T
+    T2 -->|Resolved or final| U[Persist interest_validation]
     U --> V[Emit AI activity to panel]
     V --> W[Update popup counter]
     W --> X{Limit reached?}
@@ -41,7 +47,7 @@ flowchart TD
 - Failures in extraction should be observable and should not corrupt stored results.
 - Export is local-only in the current phase.
 - The LinkedIn panel downloads the latest stable result snapshot and disables download while the crawler, enrichment, or AI validation is running.
-- Author enrichment is sequential, preserves partial progress on cancellation, and the latest download composes that snapshot with the latest AI validation overlay.
+- Author enrichment is sequential, preserves partial progress on cancellation, skips cache writes for authors without useful role or follower signals, and the latest download composes that snapshot with the latest AI validation overlay.
 - Enriched author classification may end in `trivial` when enrichment cannot find followers or a strong enough role signal; `low` is reserved for authors with real but weak follower evidence.
 - Non-organic feed items are excluded before they enter normalized storage.
-- Gemini validation runs after capture, uses fixed-size chunks, and may leave posts in `pending` or `unknown` when quota pressure or errors occur.
+- Gemini validation runs after capture, uses fixed-size sequential chunks, blocks later chunks during backoff, and may leave retryable provider failures as `unresolved` when attempts are exhausted.

--- a/popup.html
+++ b/popup.html
@@ -54,9 +54,14 @@
               placeholder="Enter custom instructions for the AI..."
             ></textarea>
           </label>
-          <button id="save-ai-config" type="button" class="primary-button">
-            Save AI configuration
-          </button>
+          <div class="ai-config-actions">
+            <button id="reset-ai-prompt" type="button" class="secondary-button">
+              Reset Prompt
+            </button>
+            <button id="save-ai-config" type="button" class="primary-button">
+              Save AI configuration
+            </button>
+          </div>
         </div>
       </section>
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -14,6 +14,7 @@ import {
   buildAuthorSignalPatch,
   normalizeAuthorName,
 } from "../shared/author-weight.js";
+import { hasCacheableAuthorSignals, isEmptyAuthorCacheEntry } from "../shared/author-cache.js";
 import {
   buildResultFilename,
   serializeExportItems,
@@ -39,6 +40,7 @@ import {
   failEnrichment,
   finalizeStopCrawler,
   getAiValidationEligibleItems,
+  getAiValidationItemsByFingerprint,
   getEnrichedItems,
   getLatestResultItems,
   getSerializableState,
@@ -303,6 +305,7 @@ async function handleMessage(message, sender) {
         totalChunks,
         completedChunks: 0,
         currentChunkIndex: 1,
+        activeChunkFingerprints: [],
         lastMessage: "Starting AI validation bulk run.",
       });
       await broadcastAiActivity(
@@ -320,9 +323,19 @@ async function handleMessage(message, sender) {
       }
 
       const activeRun = activeAiValidationRuns.get(tabId);
+      await chrome.alarms.clear(`${AI_RETRY_ALARM_PREFIX}${tabId}`);
 
       if (!activeRun) {
-        return { ok: true, state: getSerializableState(tabId) };
+        const state = await setAiQueueState(tabId, {
+          phase: AI_QUEUE_PHASES.cancelled,
+          retryAfterUntil: null,
+          lastError: null,
+          activeChunkFingerprints: [],
+          lastMessage: "AI validation cancellation requested.",
+        });
+        await broadcastAiActivity(tabId, "AI validation cancellation requested.");
+        await broadcastCountUpdated(tabId, state);
+        return { ok: true, state };
       }
 
       activeRun.cancelled = true;
@@ -330,6 +343,7 @@ async function handleMessage(message, sender) {
         phase: AI_QUEUE_PHASES.cancelled,
         retryAfterUntil: null,
         lastError: null,
+        activeChunkFingerprints: [],
         lastMessage: "AI validation cancellation requested.",
       });
       await broadcastAiActivity(tabId, "AI validation cancellation requested.");
@@ -771,6 +785,7 @@ async function runAiValidation(tabId, run) {
         phase: AI_QUEUE_PHASES.cancelled,
         retryAfterUntil: null,
         lastError: null,
+        activeChunkFingerprints: [],
         lastMessage: "AI validation cancelled.",
       });
       await broadcastAiActivity(tabId, "AI validation cancelled.");
@@ -778,7 +793,21 @@ async function runAiValidation(tabId, run) {
       return;
     }
 
-    const eligibleItems = getAiValidationEligibleItems(tabId);
+    const queuedState = getSerializableState(tabId);
+    const activeChunkFingerprints = queuedState.aiQueue?.activeChunkFingerprints || [];
+    let eligibleItems = getAiValidationEligibleItems(tabId);
+    let chunk =
+      activeChunkFingerprints.length > 0
+        ? getAiValidationItemsByFingerprint(tabId, activeChunkFingerprints)
+        : [];
+
+    if (activeChunkFingerprints.length > 0 && !chunk.length) {
+      const clearedState = await setAiQueueState(tabId, {
+        activeChunkFingerprints: [],
+      });
+      await broadcastCountUpdated(tabId, clearedState);
+      eligibleItems = getAiValidationEligibleItems(tabId);
+    }
 
     if (!eligibleItems.length) {
       const completedState = await setAiQueueState(tabId, {
@@ -786,6 +815,7 @@ async function runAiValidation(tabId, run) {
         retryAfterUntil: null,
         lastError: null,
         currentChunkIndex: 0,
+        activeChunkFingerprints: [],
         lastMessage: "AI validation completed for the current batch.",
       });
       await broadcastAiActivity(
@@ -812,7 +842,14 @@ async function runAiValidation(tabId, run) {
 
     await pauseForRateLimit(tabId);
 
-    const chunk = eligibleItems.slice(0, AI_RATE_LIMIT.chunkSize);
+    if (run.cancelled) {
+      continue;
+    }
+
+    if (!chunk.length) {
+      chunk = eligibleItems.slice(0, AI_RATE_LIMIT.chunkSize);
+    }
+
     const stateBeforeChunk = getSerializableState(tabId);
     const currentChunkIndex = Math.min(
       (stateBeforeChunk.aiQueue?.completedChunks || 0) + 1,
@@ -828,6 +865,7 @@ async function runAiValidation(tabId, run) {
       lastError: null,
       lastRequestAt: new Date().toISOString(),
       currentChunkIndex,
+      activeChunkFingerprints: chunk.map((item) => item.fingerprint),
       lastMessage: `Running AI validation chunk ${currentChunkIndex}/${stateBeforeChunk.aiQueue?.totalChunks || 1}.`,
     });
     await broadcastCountUpdated(tabId, processingState);
@@ -865,10 +903,7 @@ async function runAiValidation(tabId, run) {
         retryAfterUntil: null,
         lastError: null,
         lastRequestAt: new Date().toISOString(),
-        processedPosts: Math.min(
-          updatedState.aiQueue.totalPosts,
-          (updatedState.aiQueue.processedPosts || 0) + chunk.length
-        ),
+        processedPosts: updatedState.aiCounts.interested + updatedState.aiCounts.not_interested,
         completedChunks: Math.min(
           updatedState.aiQueue.totalChunks,
           (updatedState.aiQueue.completedChunks || 0) + 1
@@ -877,6 +912,7 @@ async function runAiValidation(tabId, run) {
           updatedState.aiQueue.totalChunks,
           (updatedState.aiQueue.completedChunks || 0) + 2
         ),
+        activeChunkFingerprints: [],
         lastMessage: `Chunk ${currentChunkIndex}/${updatedState.aiQueue.totalChunks} completed.`,
       });
       const interestedCount = chunk.filter((item) => interestedIds.has(item.fingerprint)).length;
@@ -897,14 +933,20 @@ async function runAiValidation(tabId, run) {
       const shouldRetry = shouldRetryGeminiError(normalizedError, attempts);
 
       if (!shouldRetry) {
+        const retryableError = isRetryableAiError(normalizedError);
+        const retryAfterUntil = buildRetryAfterUntil(normalizedError.retryAfterMs);
         const updatedState = await updateInterestValidationBatch(
           tabId,
           chunk.map((item) => ({
             fingerprint: item.fingerprint,
             validationPatch: buildValidationResult(
-              AI_STATUS.unknown,
+              retryableError ? AI_STATUS.unresolved : AI_STATUS.unknown,
               attempts,
-              normalizedError.kind
+              normalizedError.kind,
+              {
+                retryAfterMs: normalizedError.retryAfterMs,
+                retryAfterUntil,
+              }
             ),
           }))
         );
@@ -912,10 +954,6 @@ async function runAiValidation(tabId, run) {
           phase: AI_QUEUE_PHASES.failed,
           retryAfterUntil: null,
           lastError: normalizedError.message,
-          processedPosts: Math.min(
-            updatedState.aiQueue.totalPosts,
-            (updatedState.aiQueue.processedPosts || 0) + chunk.length
-          ),
           completedChunks: Math.min(
             updatedState.aiQueue.totalChunks,
             (updatedState.aiQueue.completedChunks || 0) + 1
@@ -924,7 +962,10 @@ async function runAiValidation(tabId, run) {
             updatedState.aiQueue.totalChunks,
             (updatedState.aiQueue.completedChunks || 0) + 2
           ),
-          lastMessage: `Chunk ${currentChunkIndex}/${updatedState.aiQueue.totalChunks} failed and was marked unknown.`,
+          activeChunkFingerprints: [],
+          lastMessage: retryableError
+            ? `Chunk ${currentChunkIndex}/${updatedState.aiQueue.totalChunks} unresolved after provider overload. Retry later.`
+            : `Chunk ${currentChunkIndex}/${updatedState.aiQueue.totalChunks} failed and was marked unknown.`,
         });
         logServiceWorkerEvent("ai-validation-chunk-failed", {
           tabId,
@@ -933,10 +974,10 @@ async function runAiValidation(tabId, run) {
           attempts,
           message: normalizedError.message,
         });
-        await broadcastAiActivity(
-          tabId,
-          `AI validation chunk ${currentChunkIndex}/${failedState.aiQueue.totalChunks} failed. ${chunk.length} posts marked unknown.`
-        );
+        const failedMessage = retryableError
+          ? `AI validation chunk ${currentChunkIndex}/${failedState.aiQueue.totalChunks} unresolved after provider overload. Retry later.`
+          : `AI validation chunk ${currentChunkIndex}/${failedState.aiQueue.totalChunks} failed. ${chunk.length} posts marked unknown.`;
+        await broadcastAiActivity(tabId, failedMessage);
         await broadcastCountUpdated(tabId, failedState);
         continue;
       }
@@ -958,6 +999,7 @@ async function runAiValidation(tabId, run) {
         retryAfterUntil: retryUntil,
         lastError: normalizedError.message,
         currentChunkIndex,
+        activeChunkFingerprints: chunk.map((item) => item.fingerprint),
         lastMessage: `Backing off before retrying chunk ${currentChunkIndex}.`,
       });
       logServiceWorkerEvent("ai-validation-chunk-backoff", {
@@ -971,7 +1013,7 @@ async function runAiValidation(tabId, run) {
       });
       await broadcastAiActivity(
         tabId,
-        `AI validation backing off before retrying chunk ${currentChunkIndex}/${queueState.aiQueue.totalChunks}.`
+        `AI validation chunk ${currentChunkIndex}/${queueState.aiQueue.totalChunks} waiting ${Math.ceil(retryDelayMs / 1000)}s before retry due to provider overload.`
       );
       await broadcastCountUpdated(tabId, queueState);
       await scheduleValidationRetryAlarm(tabId, retryDelayMs);
@@ -1047,10 +1089,7 @@ async function runEnrichment(tabId) {
         processedPosts,
         currentAuthor: bucket.author,
         currentPostIndex: processedPosts,
-        lastMessage:
-          authorData.source === "cache"
-            ? `Cache hit for ${bucket.author}.`
-            : `Profile resolved for ${bucket.author}.`,
+        lastMessage: getAuthorResolutionMessage(bucket.author, authorData.cacheDisposition),
       });
       await broadcastCountUpdated(tabId, progressState);
     }
@@ -1105,7 +1144,7 @@ function countDistinctAuthors(items) {
 }
 
 async function resolveAuthorData(bucket, tabId) {
-  const cacheEntry = await findAuthorCacheEntry(bucket);
+  const cacheEntry = await findAuthorCacheEntry(bucket, tabId);
 
   if (cacheEntry) {
     logServiceWorkerEvent("author-cache-hit", {
@@ -1113,7 +1152,7 @@ async function resolveAuthorData(bucket, tabId) {
       author: bucket.author,
       cacheKey: cacheEntry.cacheKey,
     });
-    return { ...cacheEntry.entry, source: "cache" };
+    return { ...cacheEntry.entry, source: "cache", cacheDisposition: "cache-hit" };
   }
 
   logServiceWorkerEvent("author-cache-miss", {
@@ -1127,6 +1166,7 @@ async function resolveAuthorData(bucket, tabId) {
       role: null,
       followers: null,
       source: "fallback",
+      cacheDisposition: "skipped-empty",
     };
   }
 
@@ -1140,30 +1180,71 @@ async function resolveAuthorData(bucket, tabId) {
     resolved_at: new Date().toISOString(),
   };
 
+  if (!hasCacheableAuthorSignals(entry)) {
+    logServiceWorkerEvent("author-cache-skipped-empty", {
+      tabId,
+      author: bucket.author,
+      profileUrl: bucket.profileUrl,
+    });
+    return { ...entry, source: "profile", cacheDisposition: "skipped-empty" };
+  }
+
   await upsertAuthorCacheEntry(bucket, {
     ...entry,
     ...buildAuthorSignalPatch(entry),
   });
 
-  return { ...entry, source: "profile" };
+  return { ...entry, source: "profile", cacheDisposition: "cached" };
 }
 
-async function findAuthorCacheEntry(bucket) {
+async function findAuthorCacheEntry(bucket, tabId) {
   const stored = await chrome.storage.local.get(STORAGE_KEYS.authorCache);
   const cache = stored[STORAGE_KEYS.authorCache] || {};
+  const cacheKeys = [bucket.cacheKey, bucket.fallbackAuthorKey].filter(Boolean);
+  const emptyCacheKeys = [];
 
-  if (bucket.cacheKey && cache[bucket.cacheKey]) {
-    return { cacheKey: bucket.cacheKey, entry: cache[bucket.cacheKey] };
+  for (const cacheKey of cacheKeys) {
+    const entry = cache[cacheKey];
+
+    if (!entry) {
+      continue;
+    }
+
+    if (!isEmptyAuthorCacheEntry(entry)) {
+      return { cacheKey, entry };
+    }
+
+    emptyCacheKeys.push(cacheKey);
   }
 
-  if (bucket.fallbackAuthorKey && cache[bucket.fallbackAuthorKey]) {
-    return {
-      cacheKey: bucket.fallbackAuthorKey,
-      entry: cache[bucket.fallbackAuthorKey],
-    };
+  if (emptyCacheKeys.length) {
+    for (const cacheKey of emptyCacheKeys) {
+      delete cache[cacheKey];
+    }
+
+    await chrome.storage.local.set({
+      [STORAGE_KEYS.authorCache]: cache,
+    });
+    logServiceWorkerEvent("author-cache-empty-entry-evicted", {
+      tabId,
+      author: bucket.author,
+      cacheKeys: emptyCacheKeys,
+    });
   }
 
   return null;
+}
+
+function getAuthorResolutionMessage(author, cacheDisposition) {
+  if (cacheDisposition === "cache-hit") {
+    return `Cache hit for ${author}.`;
+  }
+
+  if (cacheDisposition === "skipped-empty") {
+    return `No cacheable author signals for ${author}. Will retry on a future run.`;
+  }
+
+  return `Profile resolved for ${author}.`;
 }
 
 async function upsertAuthorCacheEntry(bucket, entry) {
@@ -1257,6 +1338,18 @@ function normalizeAiError(error) {
   const nextError = new Error(error?.message || "Unexpected AI validation error.");
   nextError.kind = "network-error";
   return nextError;
+}
+
+function isRetryableAiError(error) {
+  return ["rate-limited", "quota-exhausted", "network-error", "server-error"].includes(error?.kind);
+}
+
+function buildRetryAfterUntil(retryAfterMs) {
+  if (typeof retryAfterMs !== "number" || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
+    return null;
+  }
+
+  return new Date(Date.now() + retryAfterMs).toISOString();
 }
 
 async function scheduleValidationRetryAlarm(tabId, delayMs) {

--- a/src/background/default-system-instruction.js
+++ b/src/background/default-system-instruction.js
@@ -14,12 +14,21 @@ Marca como not_interested cuando el objetivo dominante sea vender, promocionar, 
 
 Tambien marca como not_interested el PR comercial, lanzamientos de producto o feature, anuncios de empresa, upsells, ofertas, webinars o eventos usados como lead-gen, casos de exito usados para vender y CTAs como book a call, request demo, contact us, compra, registrate o agenda una llamada.
 
+Marca como not_interested tambien podcasts, newsletters, posts de "listen/watch/read the full episode", eventos, summits, conferencias, charlas, book launches, links a reportes, links a articulos propios, publicaciones de marca o empresa, y posts que piden asistir, registrarse, escuchar, leer, descargar, visitar, probar, comprar, contactar o comentar para recibir algo.
+
 Si un post comercial contiene algun insight util pero sigue principalmente promocionando una empresa, producto, servicio, oferta o accion comercial, responde not_interested.
 
 No descartes automaticamente un post solo porque menciona una empresa o producto como contexto; si no busca vender y aporta analisis independiente o aprendizaje transferible, puede ser interested.
 
 Ejemplos interested: historia propia con aprendizaje general sin venta directa; analisis de una decision tecnica o de negocio; opinion profesional sobre una tendencia con sustancia.
 
-Ejemplos not_interested: lanzamiento de producto o feature; invitacion a demo o llamada; promocion de servicio, oferta, webinar lead-gen o caso de exito comercial; post con CTA comercial claro.
+Ejemplos not_interested:
+- "I'm speaking at our free virtual summit. Register here / I'd love to see you there." Motivo: evento usado como lead-gen.
+- "We shipped/launched X. Try it here / link." Motivo: lanzamiento o promocion de producto.
+- "Listen to the full episode / links in comments / subscribe." Motivo: promocion de podcast, newsletter o contenido propio.
+- "Our company/client/event grew revenue, clients or market presence." Motivo: PR comercial o promocion de empresa.
+- "Useful insight + book a call, request demo, contact us, download the report, register, buy, try." Motivo: CTA comercial dominante.
+
+Antes de responder interested, haz esta comprobacion final: si el post tiene CTA comercial, link promocional, evento/summit, podcast/newsletter, lanzamiento, oferta, demo, compra, registro, descarga, contacto, contenido de marca o PR de empresa, responde not_interested aunque incluya algun insight util.
 
 Si hay duda, responde not_interested.`;

--- a/src/background/default-system-instruction.js
+++ b/src/background/default-system-instruction.js
@@ -1,29 +1,3 @@
-export const LEGACY_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts para un perfil profesional que quiere comentar donde pueda aportar una observacion util, estrategica o experta.
-
-Prioriza contenido con sustancia, opinion, aprendizaje, industria, liderazgo, tecnologia, negocio o temas donde un comentario bien pensado agregaria valor.
-
-Marca como not_interested el contenido vacio, demasiado personal, celebratorio sin contenido, engagement bait, autopromocion obvia o posts sin un angulo claro para comentar.
-
-Si hay duda, responde not_interested.`;
-
-export const PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts de LinkedIn para un perfil profesional que quiere comentar solo donde pueda aportar una observacion util, estrategica o experta y conectar con profesionales valiosos y sus audiencias.
-
-Marca como interested cuando el objetivo dominante sea una conversacion profesional con sustancia: experiencia personal con aprendizaje transferible, analisis independiente, opinion fundada, liderazgo, tecnologia, industria, negocio o decisiones donde un comentario experto agregaria valor.
-
-Marca como not_interested cuando el objetivo dominante sea vender, promocionar, anunciar, generar leads, pedir demos, ofrecer productos o servicios, pedir contacto, empujar una conversion comercial o llevar trafico a una oferta.
-
-Tambien marca como not_interested el PR comercial, lanzamientos de producto o feature, anuncios de empresa, upsells, ofertas, webinars o eventos usados como lead-gen, casos de exito usados para vender y CTAs como book a call, request demo, contact us, compra, registrate o agenda una llamada.
-
-Si un post comercial contiene algun insight util pero sigue principalmente promocionando una empresa, producto, servicio, oferta o accion comercial, responde not_interested.
-
-No descartes automaticamente un post solo porque menciona una empresa o producto como contexto; si no busca vender y aporta analisis independiente o aprendizaje transferible, puede ser interested.
-
-Ejemplos interested: historia propia con aprendizaje general sin venta directa; analisis de una decision tecnica o de negocio; opinion profesional sobre una tendencia con sustancia.
-
-Ejemplos not_interested: lanzamiento de producto o feature; invitacion a demo o llamada; promocion de servicio, oferta, webinar lead-gen o caso de exito comercial; post con CTA comercial claro.
-
-Si hay duda, responde not_interested.`;
-
 export const DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts de LinkedIn para un perfil profesional que quiere comentar solo donde pueda aportar una observacion util, estrategica o experta y conectar con profesionales valiosos y sus audiencias.
 
 Marca como interested cuando el objetivo dominante sea una conversacion profesional con sustancia: experiencia personal con aprendizaje transferible, analisis independiente, opinion fundada, liderazgo, tecnologia, industria, negocio o decisiones donde un comentario experto agregaria valor.

--- a/src/background/default-system-instruction.js
+++ b/src/background/default-system-instruction.js
@@ -6,6 +6,24 @@ Marca como not_interested el contenido vacio, demasiado personal, celebratorio s
 
 Si hay duda, responde not_interested.`;
 
+export const PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts de LinkedIn para un perfil profesional que quiere comentar solo donde pueda aportar una observacion util, estrategica o experta y conectar con profesionales valiosos y sus audiencias.
+
+Marca como interested cuando el objetivo dominante sea una conversacion profesional con sustancia: experiencia personal con aprendizaje transferible, analisis independiente, opinion fundada, liderazgo, tecnologia, industria, negocio o decisiones donde un comentario experto agregaria valor.
+
+Marca como not_interested cuando el objetivo dominante sea vender, promocionar, anunciar, generar leads, pedir demos, ofrecer productos o servicios, pedir contacto, empujar una conversion comercial o llevar trafico a una oferta.
+
+Tambien marca como not_interested el PR comercial, lanzamientos de producto o feature, anuncios de empresa, upsells, ofertas, webinars o eventos usados como lead-gen, casos de exito usados para vender y CTAs como book a call, request demo, contact us, compra, registrate o agenda una llamada.
+
+Si un post comercial contiene algun insight util pero sigue principalmente promocionando una empresa, producto, servicio, oferta o accion comercial, responde not_interested.
+
+No descartes automaticamente un post solo porque menciona una empresa o producto como contexto; si no busca vender y aporta analisis independiente o aprendizaje transferible, puede ser interested.
+
+Ejemplos interested: historia propia con aprendizaje general sin venta directa; analisis de una decision tecnica o de negocio; opinion profesional sobre una tendencia con sustancia.
+
+Ejemplos not_interested: lanzamiento de producto o feature; invitacion a demo o llamada; promocion de servicio, oferta, webinar lead-gen o caso de exito comercial; post con CTA comercial claro.
+
+Si hay duda, responde not_interested.`;
+
 export const DEFAULT_GEMINI_SYSTEM_INSTRUCTION = `Clasifica posts de LinkedIn para un perfil profesional que quiere comentar solo donde pueda aportar una observacion util, estrategica o experta y conectar con profesionales valiosos y sus audiencias.
 
 Marca como interested cuando el objetivo dominante sea una conversacion profesional con sustancia: experiencia personal con aprendizaje transferible, analisis independiente, opinion fundada, liderazgo, tecnologia, industria, negocio o decisiones donde un comentario experto agregaria valor.

--- a/src/background/gemini.js
+++ b/src/background/gemini.js
@@ -129,13 +129,20 @@ export async function validatePostsInterestBulk(items, config, options = {}) {
   };
 }
 
-export function buildValidationResult(status, attempts, error = null) {
+export function buildValidationResult(status, attempts, error = null, options = {}) {
+  const retryAfterMs =
+    typeof options.retryAfterMs === "number" && Number.isFinite(options.retryAfterMs)
+      ? options.retryAfterMs
+      : null;
+
   return {
     status,
     source: "gemini",
     attempts,
     validated_at: new Date().toISOString(),
     error,
+    retry_after_ms: retryAfterMs,
+    retry_after_until: options.retryAfterUntil || null,
   };
 }
 

--- a/src/background/gemini.js
+++ b/src/background/gemini.js
@@ -1,8 +1,4 @@
 import { AI_DEFAULT_CONFIG, AI_RATE_LIMIT, AI_STATUS, STORAGE_KEYS } from "../shared/constants.js";
-import {
-  LEGACY_GEMINI_SYSTEM_INSTRUCTION,
-  PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
-} from "./default-system-instruction.js";
 
 const GEMINI_API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -39,30 +35,7 @@ function normalizeSystemInstruction(systemInstruction) {
     return AI_DEFAULT_CONFIG.systemInstruction;
   }
 
-  if (isMigratableDefaultInstruction(trimmedInstruction)) {
-    return AI_DEFAULT_CONFIG.systemInstruction;
-  }
-
   return trimmedInstruction;
-}
-
-function isMigratableDefaultInstruction(systemInstruction) {
-  const normalizedInstruction = normalizeInstructionForComparison(systemInstruction);
-  const migratableDefaults = [
-    LEGACY_GEMINI_SYSTEM_INSTRUCTION,
-    PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
-  ];
-
-  return migratableDefaults.some(
-    (defaultInstruction) =>
-      normalizedInstruction === normalizeInstructionForComparison(defaultInstruction)
-  );
-}
-
-function normalizeInstructionForComparison(systemInstruction) {
-  return String(systemInstruction || "")
-    .replace(/\r\n/g, "\n")
-    .trim();
 }
 
 export function getAiConfigError(config) {

--- a/src/background/gemini.js
+++ b/src/background/gemini.js
@@ -1,5 +1,8 @@
 import { AI_DEFAULT_CONFIG, AI_RATE_LIMIT, AI_STATUS, STORAGE_KEYS } from "../shared/constants.js";
-import { LEGACY_GEMINI_SYSTEM_INSTRUCTION } from "./default-system-instruction.js";
+import {
+  LEGACY_GEMINI_SYSTEM_INSTRUCTION,
+  PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
+} from "./default-system-instruction.js";
 
 const GEMINI_API_ROOT = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -36,14 +39,24 @@ function normalizeSystemInstruction(systemInstruction) {
     return AI_DEFAULT_CONFIG.systemInstruction;
   }
 
-  if (
-    normalizeInstructionForComparison(trimmedInstruction) ===
-    normalizeInstructionForComparison(LEGACY_GEMINI_SYSTEM_INSTRUCTION)
-  ) {
+  if (isMigratableDefaultInstruction(trimmedInstruction)) {
     return AI_DEFAULT_CONFIG.systemInstruction;
   }
 
   return trimmedInstruction;
+}
+
+function isMigratableDefaultInstruction(systemInstruction) {
+  const normalizedInstruction = normalizeInstructionForComparison(systemInstruction);
+  const migratableDefaults = [
+    LEGACY_GEMINI_SYSTEM_INSTRUCTION,
+    PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
+  ];
+
+  return migratableDefaults.some(
+    (defaultInstruction) =>
+      normalizedInstruction === normalizeInstructionForComparison(defaultInstruction)
+  );
 }
 
 function normalizeInstructionForComparison(systemInstruction) {

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -1,5 +1,6 @@
 import {
   cleanPersonLabel as sharedCleanPersonLabel,
+  extractPostEngagement as extractSharedPostEngagement,
   extractPostText as extractSharedPostText,
   normalizeWhitespace as sharedNormalizeWhitespace,
   stripExpandableSuffix as sharedStripExpandableSuffix,
@@ -57,6 +58,7 @@ import {
     interested: "interested",
     notInterested: "not_interested",
     unknown: "unknown",
+    unresolved: "unresolved",
   };
 
   const MESSAGE_TYPES = {
@@ -563,6 +565,7 @@ import {
       interested: 0,
       not_interested: 0,
       unknown: 0,
+      unresolved: 0,
     };
   }
 
@@ -663,6 +666,10 @@ import {
 
     if ((nextAiCounts.unknown || 0) > (uiState.aiCounts.unknown || 0)) {
       pushActivity("AI marked a chunk as unknown after retries.");
+    }
+
+    if ((nextAiCounts.unresolved || 0) > (uiState.aiCounts.unresolved || 0)) {
+      pushActivity("AI left a chunk unresolved after provider overload. Retry later.");
     }
   }
 
@@ -801,11 +808,7 @@ import {
   }
 
   function getAiDoneCount() {
-    return (
-      (uiState.aiCounts.interested || 0) +
-      (uiState.aiCounts.not_interested || 0) +
-      (uiState.aiCounts.unknown || 0)
-    );
+    return (uiState.aiCounts.interested || 0) + (uiState.aiCounts.not_interested || 0);
   }
 
   function hasAiResults() {
@@ -1281,6 +1284,8 @@ import {
   }
 
   function buildNormalizedItem(postElement, author, repostMetadata, now) {
+    const engagement = extractSharedPostEngagement(postElement);
+
     return {
       link: null,
       author: author,
@@ -1291,6 +1296,10 @@ import {
       is_repost: repostMetadata.is_repost,
       type: "organic",
       extracted_at: now.toISOString(),
+      comment_count: engagement.comment_count,
+      comment_count_text: engagement.comment_count_text,
+      reaction_count: engagement.reaction_count,
+      reaction_count_text: engagement.reaction_count_text,
       author_role: null,
       author_followers: null,
       author_weight: "low",

--- a/src/shared/author-cache.js
+++ b/src/shared/author-cache.js
@@ -1,0 +1,21 @@
+import { parseFollowerCount } from "./author-weight.js";
+
+export function hasCacheableAuthorSignals({ role, followers } = {}) {
+  return hasUsefulRole(role) || hasUsefulFollowers(followers);
+}
+
+export function isEmptyAuthorCacheEntry(entry) {
+  return !hasCacheableAuthorSignals({
+    role: entry?.role ?? entry?.author_role,
+    followers: entry?.followers ?? entry?.author_followers,
+  });
+}
+
+function hasUsefulRole(role) {
+  return String(role || "").trim().length > 0;
+}
+
+function hasUsefulFollowers(followers) {
+  const parsedFollowers = parseFollowerCount(followers);
+  return typeof parsedFollowers === "number" && parsedFollowers > 0;
+}

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -21,6 +21,7 @@ export const AI_STATUS = {
   interested: "interested",
   notInterested: "not_interested",
   unknown: "unknown",
+  unresolved: "unresolved",
 };
 export const AI_QUEUE_PHASES = {
   idle: "idle",

--- a/src/shared/export.js
+++ b/src/shared/export.js
@@ -9,6 +9,10 @@ function pickExportFields(item) {
     is_repost: Boolean(item?.is_repost),
     type: item?.type || "organic",
     extracted_at: item?.extracted_at || null,
+    comment_count: typeof item?.comment_count === "number" ? item.comment_count : null,
+    comment_count_text: item?.comment_count_text || null,
+    reaction_count: typeof item?.reaction_count === "number" ? item.reaction_count : null,
+    reaction_count_text: item?.reaction_count_text || null,
     interest_validation: item?.interest_validation || null,
   };
 }

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -8,6 +8,9 @@ const OVERFLOW_BUTTON_SELECTOR = 'button[aria-label*="Open control menu for post
 const FLOATING_MENU_SELECTOR = 'div[popover="manual"] [role="menu"]';
 const MENU_ITEM_SELECTOR = '[role="menuitem"]';
 const POST_TEXT_BLOCK_TAGS = new Set(["P", "DIV", "LI"]);
+const COMMENT_COUNT_PATTERN = /\b(comments?|comentarios?)\b/i;
+const REACTION_COUNT_PATTERN = /\b(reactions?|likes?|reacciones?|me gusta)\b/i;
+const SHARE_COUNT_PATTERN = /\b(reposts?|shares?|compartidos?)\b/i;
 
 export function normalizeWhitespace(value) {
   return String(value || "")
@@ -415,6 +418,123 @@ export function extractPostText(postElement) {
   return extractPostTextWithBreaks(textBox);
 }
 
+export function parseEngagementCount(text) {
+  const sourceText = normalizeWhitespace(text || "");
+
+  if (!sourceText) {
+    return { value: null, text: null };
+  }
+
+  if (/^(no|sin)\s+(comments?|comentarios?|reactions?|reacciones?)\b/i.test(sourceText)) {
+    return { value: 0, text: sourceText };
+  }
+
+  const numberMatch = sourceText.match(/\d+(?:[.,]\d+)?(?:[.,]\d{3})*/);
+
+  if (!numberMatch) {
+    return { value: null, text: sourceText };
+  }
+
+  const suffixMatch = sourceText
+    .slice(numberMatch.index + numberMatch[0].length)
+    .match(/^\s*(k|m|mil)\b/i);
+  const value = parseEngagementNumber(numberMatch[0], suffixMatch?.[1] || null);
+
+  return {
+    value,
+    text: sourceText,
+  };
+}
+
+function parseEngagementNumber(numberText, suffix) {
+  const rawNumber = String(numberText || "").trim();
+  const normalizedSuffix = String(suffix || "").toLowerCase();
+
+  if (!rawNumber) {
+    return null;
+  }
+
+  if (normalizedSuffix) {
+    const normalizedDecimal = rawNumber.includes(",")
+      ? rawNumber.replace(/\./g, "").replace(",", ".")
+      : rawNumber.replace(/,/g, "");
+    const base = Number.parseFloat(normalizedDecimal);
+
+    if (!Number.isFinite(base)) {
+      return null;
+    }
+
+    const multiplier = normalizedSuffix === "m" ? 1000000 : 1000;
+    return Math.round(base * multiplier);
+  }
+
+  if (/^\d+$/.test(rawNumber)) {
+    return Number.parseInt(rawNumber, 10);
+  }
+
+  if (/^\d{1,3}(,\d{3})+$/.test(rawNumber)) {
+    return Number.parseInt(rawNumber.replace(/,/g, ""), 10);
+  }
+
+  if (/^\d{1,3}(\.\d{3})+$/.test(rawNumber)) {
+    return Number.parseInt(rawNumber.replace(/\./g, ""), 10);
+  }
+
+  return null;
+}
+
+export function extractPostEngagement(postElement) {
+  const commentSource = findEngagementSource(postElement, COMMENT_COUNT_PATTERN);
+  const reactionSource = findEngagementSource(postElement, REACTION_COUNT_PATTERN);
+  const commentCount = parseEngagementCount(commentSource);
+  const reactionCount = parseEngagementCount(reactionSource);
+
+  return {
+    comment_count: commentCount.text ? commentCount.value : null,
+    comment_count_text: commentCount.text,
+    reaction_count: reactionCount.text ? reactionCount.value : null,
+    reaction_count_text: reactionCount.text,
+  };
+}
+
+function findEngagementSource(postElement, pattern) {
+  const candidates = Array.from(
+    postElement.querySelectorAll("button, span, li, a, div[aria-label], span[aria-label]")
+  );
+  let firstUnparseableSource = null;
+
+  for (const candidate of candidates) {
+    for (const source of getEngagementSourceTexts(candidate)) {
+      if (!isEngagementSource(source, pattern)) {
+        continue;
+      }
+
+      const parsed = parseEngagementCount(source);
+
+      if (typeof parsed.value === "number") {
+        return parsed.text;
+      }
+
+      firstUnparseableSource ||= parsed.text;
+    }
+  }
+
+  return firstUnparseableSource;
+}
+
+function getEngagementSourceTexts(element) {
+  const values = [
+    normalizeWhitespace(element.textContent || ""),
+    normalizeWhitespace(element.getAttribute("aria-label") || ""),
+  ].filter(Boolean);
+
+  return [...new Set(values)].filter((value) => value.length <= 120);
+}
+
+function isEngagementSource(text, pattern) {
+  return pattern.test(text) && !SHARE_COUNT_PATTERN.test(text);
+}
+
 export function extractPostedTime(postElement) {
   const paragraphs = Array.from(postElement.querySelectorAll("p"));
 
@@ -503,6 +623,8 @@ export function buildNormalizedItem(
   now = new Date(),
   options = {}
 ) {
+  const engagement = extractPostEngagement(postElement);
+
   return {
     link: options.link || null,
     author,
@@ -513,6 +635,7 @@ export function buildNormalizedItem(
     is_repost: repostMetadata.is_repost,
     type: "organic",
     extracted_at: now.toISOString(),
+    ...engagement,
     author_role: null,
     author_followers: null,
     author_weight: "low",

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -44,9 +44,15 @@ export function cleanPersonLabel(text) {
   let cleaned = normalizeWhitespace(text);
   cleaned = cleaned.replace(/\bOpen to work\b/gi, " ");
   cleaned = cleaned.replace(/\bHiring\b/gi, " ");
+  cleaned = cleaned.replace(/\bExecutive Top Voice\b/gi, " ");
+  cleaned = cleaned.replace(/\bTop Voice\b/gi, " ");
   cleaned = cleaned.replace(/\bVerified Profile\b/gi, " ");
   cleaned = cleaned.replace(/\bPremium\b/gi, " ");
-  cleaned = cleaned.replace(/\bProfile\b\s*$/gi, " ");
+  cleaned = cleaned.replace(/Contact us/gi, " ");
+  cleaned = cleaned.replace(/\bFollow(?:ing)?\b|Follow(?:ing)?(?=[A-Z])/gi, " ");
+  cleaned = cleaned.replace(/\bProfile\b/gi, " ");
+  cleaned = cleaned.replace(/\s*\d+\s*(?:s|m|h|d|w|mo|y)\b(?:\s+Edited)?\s*$/i, " ");
+  cleaned = cleaned.replace(/\bEdited\b\s*$/gi, " ");
   cleaned = cleaned.replace(/[,:]+/g, " ");
   cleaned = cleaned.replace(/[•·]+/g, " ");
   cleaned = cleaned.replace(/â€¢|Ã¢â‚¬Â¢|Ã‚Â·/g, " ");
@@ -54,8 +60,23 @@ export function cleanPersonLabel(text) {
   cleaned = cleaned.replace(/[\u2022\u00B7]+/g, " ");
   cleaned = cleaned.replace(/\s+[\u2022\u00B7]+\s*$/g, " ");
   cleaned = normalizeWhitespace(cleaned);
+  cleaned = removeDuplicatedLabel(cleaned);
 
   return cleaned || null;
+}
+
+function removeDuplicatedLabel(text) {
+  const parts = normalizeWhitespace(text).split(" ");
+
+  if (parts.length % 2 !== 0) {
+    return text;
+  }
+
+  const midpoint = parts.length / 2;
+  const firstHalf = parts.slice(0, midpoint).join(" ");
+  const secondHalf = parts.slice(midpoint).join(" ");
+
+  return firstHalf.toLowerCase() === secondHalf.toLowerCase() ? firstHalf : text;
 }
 
 function hasRelationshipMarker(text) {
@@ -515,7 +536,9 @@ function findEngagementSource(postElement, pattern) {
         return parsed.text;
       }
 
-      firstUnparseableSource ||= parsed.text;
+      if (shouldKeepUnparseableEngagementText(parsed.text)) {
+        firstUnparseableSource ||= parsed.text;
+      }
     }
   }
 
@@ -532,7 +555,33 @@ function getEngagementSourceTexts(element) {
 }
 
 function isEngagementSource(text, pattern) {
-  return pattern.test(text) && !SHARE_COUNT_PATTERN.test(text);
+  return pattern.test(text) && !SHARE_COUNT_PATTERN.test(text) && !isEngagementControlText(text);
+}
+
+function isEngagementControlText(text) {
+  const normalized = normalizeWhitespace(text || "").toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  if (/^comment$|^like$|^react$/.test(normalized)) {
+    return true;
+  }
+
+  if (/^reaction button state:/.test(normalized)) {
+    return true;
+  }
+
+  if (/\b(get|add|write|leave|please)\s+(comments?|comentarios?)\b/.test(normalized)) {
+    return true;
+  }
+
+  return /\b(comment|vote)\s+(below|on|why)\b/.test(normalized);
+}
+
+function shouldKeepUnparseableEngagementText(text) {
+  return Boolean(text && !isEngagementControlText(text));
 }
 
 export function extractPostedTime(postElement) {

--- a/src/shared/state.js
+++ b/src/shared/state.js
@@ -42,6 +42,7 @@ function createEmptyAiQueueState() {
     totalChunks: 0,
     completedChunks: 0,
     currentChunkIndex: 0,
+    activeChunkFingerprints: [],
     lastMessage: null,
   };
 }
@@ -125,7 +126,11 @@ export function getSerializableState(tabId) {
     enrichedItems: tabState.enrichedItems.map(stripFingerprint),
     enrichment: { ...tabState.enrichment },
     aiCounts,
-    aiQueue: { ...tabState.aiQueue, pendingCount: aiCounts.pending },
+    aiQueue: {
+      ...tabState.aiQueue,
+      processedPosts: aiCounts.interested + aiCounts.not_interested,
+      pendingCount: aiCounts.pending,
+    },
   };
 }
 
@@ -304,6 +309,16 @@ export function getAiValidationEligibleItems(tabId) {
   return Array.from(getOrCreateTabState(tabId).itemsByFingerprint.values()).filter((item) =>
     [AI_STATUS.pending, AI_STATUS.unknown].includes(item?.interest_validation?.status)
   );
+}
+
+export function getAiValidationItemsByFingerprint(tabId, fingerprints = []) {
+  const itemsByFingerprint = getOrCreateTabState(tabId).itemsByFingerprint;
+
+  return fingerprints
+    .map((fingerprint) => itemsByFingerprint.get(fingerprint))
+    .filter((item) =>
+      [AI_STATUS.pending, AI_STATUS.unknown].includes(item?.interest_validation?.status)
+    );
 }
 
 export function resetAiValidationStatuses(tabId) {
@@ -560,6 +575,9 @@ function getAiCounts(items) {
         case AI_STATUS.unknown:
           counts.unknown += 1;
           break;
+        case AI_STATUS.unresolved:
+          counts.unresolved += 1;
+          break;
         default:
           counts.pending += 1;
           break;
@@ -572,6 +590,7 @@ function getAiCounts(items) {
       interested: 0,
       not_interested: 0,
       unknown: 0,
+      unresolved: 0,
     }
   );
 }

--- a/src/ui/popup/main.js
+++ b/src/ui/popup/main.js
@@ -6,6 +6,7 @@ const aiApiKeyInput = document.querySelector("#ai-api-key");
 const aiModelInput = document.querySelector("#ai-model");
 const aiSystemInstructionInput = document.querySelector("#ai-system-instruction");
 const saveAiConfigButton = document.querySelector("#save-ai-config");
+const resetAiPromptButton = document.querySelector("#reset-ai-prompt");
 const resetDebugButton = document.querySelector("#reset-debug-data");
 const captureFeedDumpButton = document.querySelector("#capture-feed-dump");
 const previewIgnoredButton = document.querySelector("#preview-ignored-json");
@@ -27,8 +28,26 @@ let activeState = null;
 void hydratePopup();
 
 saveAiConfigButton?.addEventListener("click", async () => {
+  await saveAiConfig({
+    feedbackText: "Saving AI config...",
+    successText: "AI config saved.",
+    button: saveAiConfigButton,
+  });
+});
+
+resetAiPromptButton?.addEventListener("click", async () => {
+  aiSystemInstructionInput.value = AI_DEFAULT_CONFIG.systemInstruction;
+  await saveAiConfig({
+    feedbackText: "Resetting prompt...",
+    successText: "Prompt reset to the current default.",
+    button: resetAiPromptButton,
+  });
+});
+
+async function saveAiConfig({ feedbackText, successText, button }) {
   saveAiConfigButton.disabled = true;
-  popupFeedback.textContent = "Saving AI config...";
+  resetAiPromptButton.disabled = true;
+  popupFeedback.textContent = feedbackText;
 
   try {
     const response = await chrome.runtime.sendMessage({
@@ -46,13 +65,15 @@ saveAiConfigButton?.addEventListener("click", async () => {
     }
 
     renderAiConfig(response.config);
-    popupFeedback.textContent = "AI config saved.";
+    popupFeedback.textContent = successText;
   } catch (error) {
     popupFeedback.textContent = error.message;
   } finally {
     saveAiConfigButton.disabled = false;
+    resetAiPromptButton.disabled = false;
+    button?.focus();
   }
-});
+}
 
 resetDebugButton?.addEventListener("click", async () => {
   if (activeTabId == null || !isLinkedInTab(activeTabUrl)) {

--- a/src/ui/popup/style.css
+++ b/src/ui/popup/style.css
@@ -189,6 +189,12 @@ h1 {
   gap: 10px;
 }
 
+.ai-config-actions {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 10px;
+}
+
 .primary-button:hover {
   background: #0052cc;
   transform: translateY(-1px);

--- a/test/author-cache.smoke.test.js
+++ b/test/author-cache.smoke.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { hasCacheableAuthorSignals, isEmptyAuthorCacheEntry } from "../src/shared/author-cache.js";
+
+describe("author cache policy", () => {
+  it("does not cache entries without useful role or follower signals", () => {
+    expect(hasCacheableAuthorSignals({ role: null, followers: null })).toBe(false);
+    expect(hasCacheableAuthorSignals({ role: "", followers: null })).toBe(false);
+  });
+
+  it("caches entries with a useful role", () => {
+    expect(hasCacheableAuthorSignals({ role: "CTO", followers: null })).toBe(true);
+  });
+
+  it("caches entries with parseable followers greater than zero", () => {
+    expect(hasCacheableAuthorSignals({ role: null, followers: "1.2k followers" })).toBe(true);
+  });
+
+  it("does not treat zero followers as cacheable without a role", () => {
+    expect(hasCacheableAuthorSignals({ role: null, followers: 0 })).toBe(false);
+    expect(hasCacheableAuthorSignals({ role: null, followers: "0 followers" })).toBe(false);
+  });
+
+  it("detects persisted empty cache entries", () => {
+    expect(isEmptyAuthorCacheEntry({ role: null, followers: null })).toBe(true);
+    expect(isEmptyAuthorCacheEntry({ author_role: null, author_followers: null })).toBe(true);
+  });
+
+  it("does not treat partially useful cache entries as empty", () => {
+    expect(isEmptyAuthorCacheEntry({ role: "Founder", followers: null })).toBe(false);
+    expect(isEmptyAuthorCacheEntry({ role: null, followers: 25 })).toBe(false);
+  });
+});

--- a/test/export.smoke.test.js
+++ b/test/export.smoke.test.js
@@ -17,11 +17,17 @@ describe("export helpers", () => {
         is_repost: false,
         type: "organic",
         extracted_at: "2026-03-23T12:00:00.000Z",
+        comment_count: 12,
+        comment_count_text: "12 comments",
+        reaction_count: 1200,
+        reaction_count_text: "1.2K reactions",
       }),
     ]);
 
     expect(json).toContain('"link": "https://example.com/post/1"');
     expect(json).toContain('"is_repost": false');
+    expect(json).toContain('"comment_count": 12');
+    expect(json).toContain('"reaction_count_text": "1.2K reactions"');
   });
 
   it("keeps enriched export fields in the preview payload", () => {
@@ -31,12 +37,27 @@ describe("export helpers", () => {
         author_role: "Engineer",
         author_followers: 1200,
         author_weight: "high",
+        comment_count: 3,
+        comment_count_text: "3 comments",
+        reaction_count: null,
+        reaction_count_text: null,
       }),
     ]);
 
     expect(json).toContain('"author_role": "Engineer"');
     expect(json).toContain('"author_followers": 1200');
     expect(json).toContain('"author_weight": "high"');
+    expect(json).toContain('"comment_count": 3');
+    expect(json).toContain('"reaction_count": null');
+  });
+
+  it("serializes legacy engagement fields as null", () => {
+    expect(toRawExportItem({ author: "Ada Lovelace" })).toMatchObject({
+      comment_count: null,
+      comment_count_text: null,
+      reaction_count: null,
+      reaction_count_text: null,
+    });
   });
 
   it("defaults enriched author_weight to trivial when signals are missing", () => {

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -5,6 +5,7 @@ import {
   analyzePostElement,
   extractAuthor,
   extractAuthorProfileUrl,
+  extractPostEngagement,
   extractPostedTime,
   extractPostText,
   extractPostTextWithBreaks,
@@ -16,6 +17,7 @@ import {
   findPostOverflowButton,
   isPromotedPost,
   isSuggestedPost,
+  parseEngagementCount,
   scanFeedPosts,
 } from "../src/shared/extractor.js";
 import { AI_STATUS } from "../src/shared/constants.js";
@@ -50,6 +52,8 @@ const FEED_FIXTURE = `
           Full organic text with a hidden ending.
           <button type="button">... more</button>
         </span>
+        <button aria-label="1,234 reactions">1,234 reactions</button>
+        <button aria-label="56 comments">56 comments</button>
       </div>
     </div>
     <div role="listitem" data-post-id="promoted-1">
@@ -192,6 +196,100 @@ function setupUnicodePostDocument() {
 }
 
 describe("LinkedIn feed smoke extraction", () => {
+  it("normalizes visible engagement counts conservatively", () => {
+    expect(parseEngagementCount("1,234 comments")).toEqual({
+      value: 1234,
+      text: "1,234 comments",
+    });
+    expect(parseEngagementCount("1.234 comentarios")).toEqual({
+      value: 1234,
+      text: "1.234 comentarios",
+    });
+    expect(parseEngagementCount("1K reactions")).toEqual({
+      value: 1000,
+      text: "1K reactions",
+    });
+    expect(parseEngagementCount("1.2K reactions")).toEqual({
+      value: 1200,
+      text: "1.2K reactions",
+    });
+    expect(parseEngagementCount("1,2 mil reacciones")).toEqual({
+      value: 1200,
+      text: "1,2 mil reacciones",
+    });
+    expect(parseEngagementCount("No comments")).toEqual({
+      value: 0,
+      text: "No comments",
+    });
+    expect(parseEngagementCount("comments are disabled")).toEqual({
+      value: null,
+      text: "comments are disabled",
+    });
+  });
+
+  it("extracts post engagement snapshots and ignores share counts", () => {
+    const document = new JSDOM(
+      `
+        <div role="listitem">
+          <button aria-label="2.5K reactions">2.5K reactions</button>
+          <button aria-label="0 comments">0 comments</button>
+          <button aria-label="99 reposts">99 reposts</button>
+        </div>
+      `,
+      {
+        url: "https://www.linkedin.com/feed/",
+      }
+    ).window.document;
+
+    expect(extractPostEngagement(document.querySelector('[role="listitem"]'))).toEqual({
+      comment_count: 0,
+      comment_count_text: "0 comments",
+      reaction_count: 2500,
+      reaction_count_text: "2.5K reactions",
+    });
+  });
+
+  it("keeps text evidence when engagement text cannot be parsed", () => {
+    const document = new JSDOM(
+      `
+        <div role="listitem">
+          <button>Many reactions</button>
+          <button>Several comments</button>
+        </div>
+      `,
+      {
+        url: "https://www.linkedin.com/feed/",
+      }
+    ).window.document;
+
+    expect(extractPostEngagement(document.querySelector('[role="listitem"]'))).toEqual({
+      comment_count: null,
+      comment_count_text: "Several comments",
+      reaction_count: null,
+      reaction_count_text: "Many reactions",
+    });
+  });
+
+  it("returns null engagement fields when no metrics are visible", () => {
+    const document = new JSDOM(
+      `
+        <div role="listitem">
+          <p>A post with no visible engagement metrics.</p>
+        </div>
+      `,
+      {
+        url: "https://www.linkedin.com/feed/",
+      }
+    ).window.document;
+
+    expect(extractPostEngagement(document.querySelector('[role="listitem"]'))).toEqual({
+      comment_count: null,
+      comment_count_text: null,
+      reaction_count: null,
+      reaction_count_text: null,
+    });
+  });
+
   it("finds the feed container and list items", () => {
     const document = setupDocument();
     const container = findFeedContainer(document);
@@ -342,6 +440,10 @@ describe("LinkedIn feed smoke extraction", () => {
       author_weight: "low",
       post_text: "Full organic text with a hidden ending.",
       posted_time: "4h",
+      comment_count: 56,
+      comment_count_text: "56 comments",
+      reaction_count: 1234,
+      reaction_count_text: "1,234 reactions",
     });
     expect(firstPass.acceptedItems.find((item) => item.author === "Liz Fong-Jones")).toMatchObject({
       author: "Liz Fong-Jones",
@@ -411,6 +513,7 @@ describe("LinkedIn feed smoke extraction", () => {
       interested: 0,
       not_interested: 0,
       unknown: 0,
+      unresolved: 0,
     });
     expect(firstMerge.state.items[0].interest_validation.status).toBe(AI_STATUS.pending);
   });

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -3,6 +3,7 @@ import { JSDOM } from "jsdom";
 import { readFileSync } from "node:fs";
 import {
   analyzePostElement,
+  cleanPersonLabel,
   extractAuthor,
   extractAuthorProfileUrl,
   extractPostEngagement,
@@ -249,6 +250,28 @@ describe("LinkedIn feed smoke extraction", () => {
     });
   });
 
+  it("ignores engagement action buttons that are not count evidence", () => {
+    const document = new JSDOM(
+      `
+        <div role="listitem">
+          <button aria-label="Reaction button state: no reaction">Like</button>
+          <button>Comment</button>
+          <p>Vote below and comment on WHY you chose that.</p>
+        </div>
+      `,
+      {
+        url: "https://www.linkedin.com/feed/",
+      }
+    ).window.document;
+
+    expect(extractPostEngagement(document.querySelector('[role="listitem"]'))).toEqual({
+      comment_count: null,
+      comment_count_text: null,
+      reaction_count: null,
+      reaction_count_text: null,
+    });
+  });
+
   it("keeps text evidence when engagement text cannot be parsed", () => {
     const document = new JSDOM(
       `
@@ -332,6 +355,16 @@ describe("LinkedIn feed smoke extraction", () => {
     expect(extractAuthor(posts[8])).toBe("Liz Fong-Jones");
     expect(extractAuthor(posts[10])).toBe("Patty Fonacier");
     expect(extractAuthor(posts[11])).toBe("Muhammad Haseeb");
+  });
+
+  it("cleans author labels polluted by LinkedIn badges and timestamps", () => {
+    expect(cleanPersonLabel("Risk Ledger1d Edited")).toBe("Risk Ledger");
+    expect(cleanPersonLabel("ComplyAdvantage4d Edited")).toBe("ComplyAdvantage");
+    expect(cleanPersonLabel("Aaron Levie Executive Top Voice")).toBe("Aaron Levie");
+    expect(cleanPersonLabel("GenAI WorksContact us2w Edited")).toBe("GenAI Works");
+    expect(cleanPersonLabel("Aakash Gupta Executive Top Voice Profile FollowingAakash Gupta")).toBe(
+      "Aakash Gupta"
+    );
   });
 
   it("extracts the author profile url when it is present in the post", () => {

--- a/test/gemini.smoke.test.js
+++ b/test/gemini.smoke.test.js
@@ -164,6 +164,21 @@ describe("gemini validation helpers", () => {
     });
   });
 
+  it("builds unresolved validation metadata with retry hints", () => {
+    expect(
+      buildValidationResult(AI_STATUS.unresolved, 3, "server-error", {
+        retryAfterMs: 45000,
+        retryAfterUntil: "2026-05-01T10:00:45.000Z",
+      })
+    ).toMatchObject({
+      status: AI_STATUS.unresolved,
+      attempts: 3,
+      error: "server-error",
+      retry_after_ms: 45000,
+      retry_after_until: "2026-05-01T10:00:45.000Z",
+    });
+  });
+
   it("parses bulk interested ids and ignores duplicates or unknown ids", async () => {
     const fetchImpl = vi.fn().mockResolvedValue({
       ok: true,

--- a/test/gemini.smoke.test.js
+++ b/test/gemini.smoke.test.js
@@ -8,11 +8,7 @@ import {
   validatePostsInterestBulk,
   validatePostInterest,
 } from "../src/background/gemini.js";
-import {
-  DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
-  LEGACY_GEMINI_SYSTEM_INSTRUCTION,
-  PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
-} from "../src/background/default-system-instruction.js";
+import { DEFAULT_GEMINI_SYSTEM_INSTRUCTION } from "../src/background/default-system-instruction.js";
 import { AI_RATE_LIMIT, AI_STATUS } from "../src/shared/constants.js";
 
 describe("gemini validation helpers", () => {
@@ -71,24 +67,8 @@ describe("gemini validation helpers", () => {
     expect(prompt).toContain("download the report");
   });
 
-  it("migrates the exact legacy default system instruction to the new default", () => {
-    const config = normalizeAiConfig({
-      systemInstruction: `\r\n${LEGACY_GEMINI_SYSTEM_INSTRUCTION.replace(/\n/g, "\r\n")}\r\n`,
-    });
-
-    expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
-  });
-
-  it("migrates the previous built-in default system instruction to the new default", () => {
-    const config = normalizeAiConfig({
-      systemInstruction: PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
-    });
-
-    expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
-  });
-
   it("preserves custom system instructions instead of overwriting them", () => {
-    const customInstruction = `${LEGACY_GEMINI_SYSTEM_INSTRUCTION}\n\nCustom scoring note.`;
+    const customInstruction = `${DEFAULT_GEMINI_SYSTEM_INSTRUCTION}\n\nCustom scoring note.`;
     const config = normalizeAiConfig({
       systemInstruction: customInstruction,
     });

--- a/test/gemini.smoke.test.js
+++ b/test/gemini.smoke.test.js
@@ -11,6 +11,7 @@ import {
 import {
   DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
   LEGACY_GEMINI_SYSTEM_INSTRUCTION,
+  PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
 } from "../src/background/default-system-instruction.js";
 import { AI_RATE_LIMIT, AI_STATUS } from "../src/shared/constants.js";
 
@@ -73,6 +74,14 @@ describe("gemini validation helpers", () => {
   it("migrates the exact legacy default system instruction to the new default", () => {
     const config = normalizeAiConfig({
       systemInstruction: `\r\n${LEGACY_GEMINI_SYSTEM_INSTRUCTION.replace(/\n/g, "\r\n")}\r\n`,
+    });
+
+    expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);
+  });
+
+  it("migrates the previous built-in default system instruction to the new default", () => {
+    const config = normalizeAiConfig({
+      systemInstruction: PREVIOUS_DEFAULT_GEMINI_SYSTEM_INSTRUCTION,
     });
 
     expect(config.systemInstruction).toBe(DEFAULT_GEMINI_SYSTEM_INSTRUCTION);

--- a/test/gemini.smoke.test.js
+++ b/test/gemini.smoke.test.js
@@ -63,6 +63,11 @@ describe("gemini validation helpers", () => {
     expect(prompt).toContain("oferta");
     expect(prompt).toContain("lanzamiento");
     expect(prompt).toContain("cta");
+    expect(prompt).toContain("podcasts");
+    expect(prompt).toContain("summits");
+    expect(prompt).toContain("listen to the full episode");
+    expect(prompt).toContain("register here");
+    expect(prompt).toContain("download the report");
   });
 
   it("migrates the exact legacy default system instruction to the new default", () => {

--- a/test/state.smoke.test.js
+++ b/test/state.smoke.test.js
@@ -52,7 +52,7 @@ describe("tab state debug samples", () => {
     expect(state.ignoredSamples[49].reason).toBe("reason-2");
   });
 
-  it("targets only pending and unknown posts for queue processing", async () => {
+  it("targets only pending and unknown posts for active queue processing", async () => {
     mockChromeStorage();
 
     await resetDebugState(52);
@@ -87,6 +87,18 @@ describe("tab state debug samples", () => {
               attempts: 2,
               validated_at: "2026-03-30T10:02:00.000Z",
               error: "rate-limited",
+              source: "gemini",
+            },
+          },
+          {
+            fingerprint: "fp-unresolved",
+            author: "Barbara",
+            extracted_at: "2026-03-30T10:02:30.000Z",
+            interest_validation: {
+              status: "unresolved",
+              attempts: 3,
+              validated_at: "2026-03-30T10:03:00.000Z",
+              error: "server-error",
               source: "gemini",
             },
           },
@@ -142,6 +154,18 @@ describe("tab state debug samples", () => {
               source: "gemini",
             },
           },
+          {
+            fingerprint: "fp-unresolved",
+            author: "Barbara",
+            extracted_at: "2026-03-30T10:02:00.000Z",
+            interest_validation: {
+              status: "unresolved",
+              attempts: 3,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: "server-error",
+              source: "gemini",
+            },
+          },
         ],
       },
     });
@@ -151,14 +175,16 @@ describe("tab state debug samples", () => {
 
     const state = getSerializableState(54);
     expect(state.aiCounts).toEqual({
-      pending: 2,
+      pending: 3,
       interested: 0,
       not_interested: 0,
       unknown: 0,
+      unresolved: 0,
     });
     expect(getAiValidationEligibleItems(54).map((item) => item.fingerprint)).toEqual([
       "fp-interested",
       "fp-not",
+      "fp-unresolved",
     ]);
   });
 
@@ -233,7 +259,7 @@ describe("tab state debug samples", () => {
     expect(state.aiQueue).toMatchObject({
       phase: "running",
       totalPosts: 2,
-      processedPosts: 1,
+      processedPosts: 2,
       totalChunks: 1,
       currentChunkIndex: 1,
     });
@@ -242,7 +268,59 @@ describe("tab state debug samples", () => {
       interested: 1,
       not_interested: 1,
       unknown: 0,
+      unresolved: 0,
     });
+  });
+
+  it("counts unresolved separately and excludes it from classified progress", async () => {
+    mockChromeStorage();
+
+    globalThis.chrome.storage.session.get.mockResolvedValue({
+      "collector.tab.56": {
+        items: [
+          {
+            fingerprint: "fp-interested",
+            author: "Ada",
+            extracted_at: "2026-03-30T10:00:00.000Z",
+            interest_validation: {
+              status: "interested",
+              attempts: 1,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: null,
+              source: "gemini",
+            },
+          },
+          {
+            fingerprint: "fp-unresolved",
+            author: "Grace",
+            extracted_at: "2026-03-30T10:01:00.000Z",
+            interest_validation: {
+              status: "unresolved",
+              attempts: 3,
+              validated_at: "2026-03-30T10:05:00.000Z",
+              error: "server-error",
+              source: "gemini",
+            },
+          },
+        ],
+        aiQueue: {
+          totalPosts: 2,
+          processedPosts: 2,
+        },
+      },
+    });
+
+    await hydrateStateFromStorage(56);
+
+    const state = getSerializableState(56);
+    expect(state.aiCounts).toEqual({
+      pending: 0,
+      interested: 1,
+      not_interested: 0,
+      unknown: 0,
+      unresolved: 1,
+    });
+    expect(state.aiQueue.processedPosts).toBe(1);
   });
 
   it("composes the latest enriched snapshot with AI validation from raw state", async () => {


### PR DESCRIPTION
## Summary
- add visible engagement snapshots to exports: comment/reaction counts and source text
- skip empty author-cache entries and keep empty author resolutions retryable
- make AI validation chunk/backoff handling stricter and export exhausted retryable failures as unresolved
- tighten author and engagement parsing from observed output QA
- add explicit popup Reset Prompt control instead of automatic prompt migration

## Validation
- npm run prepush
- npm run build
- manual JSON QA on exported files from local extension runs

## Manual QA Notes
- Output contract fields are present in generated JSON.
- Author cleanup improved for timestamp/badge-polluted labels.
- Gemini was rate limited in the latest run, so all 26 posts exported as unresolved; this correctly preserved retry metadata but prevented final prompt-quality validation.
- Follow-up observation from latest file: comment/reaction UI controls like 'View more options for ... comment' and 'Open reactions menu' should be ignored in a later parser hardening pass.

Closes #29
Closes #31
Closes #33