### PR TITLE
feat: export author network proximity

### DIFF
--- a/CODEX_PROJECT.md
+++ b/CODEX_PROJECT.md
@@ -86,6 +86,7 @@ This repo currently targets `Manifest V3`, `JavaScript` vanilla, and `Vite`. The
 - The main extraction contract for each item is:
   - `link`
   - `author`
+  - `author_network_proximity`
   - `reposted_by`
   - `post_text`
   - `posted_time`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Author enrichment cache for BL-002 is persisted in `chrome.storage.local` only w
 
 ## MVP Behavior
 
-- Extract `author`, `reposted_by`, `post_text`, `posted_time`, `link`, `is_repost`, `type`, `extracted_at`, and visible engagement snapshots from eligible feed posts
+- Extract `author`, `author_network_proximity`, `reposted_by`, `post_text`, `posted_time`, `link`, `is_repost`, `type`, `extracted_at`, and visible engagement snapshots from eligible feed posts
 - Read `post_text` from LinkedIn's preloaded expandable text box when present, without clicking `more`
 - Preserve LinkedIn's relative post age in `posted_time` when a clear value such as `4h` or `2w` is present
 - Start and stop crawling explicitly from the floating panel or popup instead of auto-collecting on feed load

--- a/REPO_WORK_RULES.md
+++ b/REPO_WORK_RULES.md
@@ -88,6 +88,7 @@ The repo gate is enforced as a pre-push check through `npm run prepush`.
 - Each exported item should preserve the normalized MVP contract:
   - `link`
   - `author`
+  - `author_network_proximity`
   - `reposted_by`
   - `post_text`
   - `posted_time`

--- a/docs/diagrams/collection-flow.md
+++ b/docs/diagrams/collection-flow.md
@@ -9,8 +9,8 @@ flowchart TD
     E --> F[Inspect post container]
     F --> G{Promoted, poll, or suggested?}
     G -->|Yes| H[Skip container]
-    G -->|No| I[Extract raw fields]
-    I --> J[Normalize item shape]
+    G -->|No| I[Extract raw fields<br/>including author proximity]
+    I --> J[Normalize item shape<br/>with author_network_proximity]
     J --> K[Deduplicate and store locally]
     J --> K2[Capture ignored sample buffer]
     K --> L{Optional manual pass}
@@ -50,4 +50,5 @@ flowchart TD
 - Author enrichment is sequential, preserves partial progress on cancellation, skips cache writes for authors without useful role or follower signals, and the latest download composes that snapshot with the latest AI validation overlay.
 - Enriched author classification may end in `trivial` when enrichment cannot find followers or a strong enough role signal; `low` is reserved for authors with real but weak follower evidence.
 - Non-organic feed items are excluded before they enter normalized storage.
+- The normalized raw field set always includes `author_network_proximity`, using the visible author label when LinkedIn exposes one and `null` otherwise.
 - Gemini validation runs after capture, uses fixed-size sequential chunks, blocks later chunks during backoff, and may leave retryable provider failures as `unresolved` when attempts are exhausted.

--- a/docs/json-output-contract.md
+++ b/docs/json-output-contract.md
@@ -18,6 +18,7 @@ Este documento define el contrato del JSON exportado por la extensión para comp
     "link": "https://www.linkedin.com/feed/update/...",
     "author": "Nombre Apellido",
     "author_profile_url": "https://www.linkedin.com/in/...",
+    "author_network_proximity": "1st",
     "reposted_by": null,
     "post_text": "Texto del post...",
     "posted_time": "4h",
@@ -43,22 +44,23 @@ Este documento define el contrato del JSON exportado por la extensión para comp
 
 ## Campos base (Raw y Enriched)
 
-| Campo                 | Tipo                | Nullable | Descripción                                     |
-| --------------------- | ------------------- | -------- | ----------------------------------------------- |
-| `link`                | `string`            | Sí       | URL del post.                                   |
-| `author`              | `string`            | Sí       | Autor del post (normalizado por extractor).     |
-| `author_profile_url`  | `string`            | Sí       | URL de perfil del autor (`/in/` o `/company/`). |
-| `reposted_by`         | `string`            | Sí       | Actor que reposteó/shared, si aplica.           |
-| `post_text`           | `string`            | Sí       | Texto del post extraído del bloque expandible.  |
-| `posted_time`         | `string`            | Sí       | Tiempo relativo de LinkedIn (ej. `4h`, `2w`).   |
-| `is_repost`           | `boolean`           | No       | Marca si es repost/share detectado.             |
-| `type`                | `string`            | No       | Tipo de post. En MVP: `"organic"`.              |
-| `extracted_at`        | `string` (ISO-8601) | Sí       | Timestamp de extracción.                        |
-| `comment_count`       | `number`            | Sí       | Conteo parseado de comentarios.                 |
-| `comment_count_text`  | `string`            | Sí       | Texto original de comentarios detectado en UI.  |
-| `reaction_count`      | `number`            | Sí       | Conteo parseado de reacciones.                  |
-| `reaction_count_text` | `string`            | Sí       | Texto original de reacciones detectado en UI.   |
-| `interest_validation` | `object`            | Sí       | Resultado de validación AI por item.            |
+| Campo                      | Tipo                | Nullable | Descripción                                        |
+| -------------------------- | ------------------- | -------- | -------------------------------------------------- |
+| `link`                     | `string`            | Sí       | URL del post.                                      |
+| `author`                   | `string`            | Sí       | Autor del post (normalizado por extractor).        |
+| `author_profile_url`       | `string`            | Sí       | URL de perfil del autor (`/in/` o `/company/`).    |
+| `author_network_proximity` | `string`            | Sí       | Etiqueta visible de proximidad del autor o `null`. |
+| `reposted_by`              | `string`            | Sí       | Actor que reposteó/shared, si aplica.              |
+| `post_text`                | `string`            | Sí       | Texto del post extraído del bloque expandible.     |
+| `posted_time`              | `string`            | Sí       | Tiempo relativo de LinkedIn (ej. `4h`, `2w`).      |
+| `is_repost`                | `boolean`           | No       | Marca si es repost/share detectado.                |
+| `type`                     | `string`            | No       | Tipo de post. En MVP: `"organic"`.                 |
+| `extracted_at`             | `string` (ISO-8601) | Sí       | Timestamp de extracción.                           |
+| `comment_count`            | `number`            | Sí       | Conteo parseado de comentarios.                    |
+| `comment_count_text`       | `string`            | Sí       | Texto original de comentarios detectado en UI.     |
+| `reaction_count`           | `number`            | Sí       | Conteo parseado de reacciones.                     |
+| `reaction_count_text`      | `string`            | Sí       | Texto original de reacciones detectado en UI.      |
+| `interest_validation`      | `object`            | Sí       | Resultado de validación AI por item.               |
 
 ## Campos adicionales de Enriched
 
@@ -89,6 +91,7 @@ Cuando está presente, su contrato es:
 - Export serializa únicamente arrays de items, sin wrapper de objeto (`src/shared/export.js:33`).
 - `is_repost` siempre se fuerza a booleano en export (`src/shared/export.js:9`).
 - `type` cae a `"organic"` si falta (`src/shared/export.js:10`).
+- `author_network_proximity` siempre se exporta y conserva la etiqueta visible del autor o `null` si no puede resolverse con claridad.
 - Enriched agrega `author_weight`; si no hay datos, puede quedar `"trivial"` (`src/shared/export.js:29`, `src/shared/author-weight.js:124`).
 - En `buildNormalizedItem`, el valor inicial de `author_weight` es `"low"`; enrichment puede recalcularlo (`src/shared/extractor.js:690`, `src/shared/author-weight.js:100`).
 - `interest_validation` puede venir `null` en export, aunque el estado interno inicial lo crea como `pending` (`src/shared/export.js:16`, `src/shared/state.js:555`).
@@ -115,6 +118,7 @@ Orden de decisión (`src/shared/author-weight.js:100`):
     "link": "https://www.linkedin.com/feed/update/urn:li:activity:123",
     "author": "Ada Lovelace",
     "author_profile_url": "https://www.linkedin.com/in/ada-lovelace",
+    "author_network_proximity": null,
     "reposted_by": null,
     "post_text": "Post de ejemplo",
     "posted_time": "4h",
@@ -138,6 +142,7 @@ Orden de decisión (`src/shared/author-weight.js:100`):
     "link": "https://www.linkedin.com/feed/update/urn:li:activity:123",
     "author": "Ada Lovelace",
     "author_profile_url": "https://www.linkedin.com/in/ada-lovelace",
+    "author_network_proximity": "Following",
     "reposted_by": null,
     "post_text": "Post de ejemplo",
     "posted_time": "4h",

--- a/src/content/linkedin/content.js
+++ b/src/content/linkedin/content.js
@@ -843,6 +843,28 @@ import {
     });
   }
 
+  function extractKnownRelationshipMarker(text) {
+    const normalized = normalizeWhitespace(text || "");
+
+    if (!normalized) {
+      return null;
+    }
+
+    for (const marker of RELATIONSHIP_MARKERS) {
+      const markerPattern = new RegExp(
+        `(?:^|[\\s\\u2022\\u00B7\\-])(${escapeRegExp(marker)})(?=\\s|$)`,
+        "i"
+      );
+      const match = normalized.match(markerPattern);
+
+      if (match?.[1]) {
+        return marker;
+      }
+    }
+
+    return null;
+  }
+
   function normalizePersonKey(value) {
     return normalizeWhitespace(value || "").toLowerCase();
   }
@@ -1126,6 +1148,151 @@ import {
     return null;
   }
 
+  function getUniqueElements(elements) {
+    const seen = new Set();
+    const uniqueElements = [];
+
+    for (const element of elements || []) {
+      if (!element || seen.has(element)) {
+        continue;
+      }
+
+      seen.add(element);
+      uniqueElements.push(element);
+    }
+
+    return uniqueElements;
+  }
+
+  function collectAuthorIdentityElements(postElement, author) {
+    const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+    if (!normalizedAuthor) {
+      return [];
+    }
+
+    return getUniqueElements(
+      Array.from(
+        postElement.querySelectorAll('[aria-label], a[href*="/in/"], a[href*="/company/"]')
+      )
+        .concat(Array.from(postElement.querySelectorAll("span, p, div")))
+        .filter(function (element) {
+          const text = normalizeWhitespace(
+            [element.textContent || "", element.getAttribute?.("aria-label") || ""].join(" ")
+          ).toLowerCase();
+
+          return text.includes(normalizedAuthor);
+        })
+    );
+  }
+
+  function collectIdentityContextElements(postElement, identityElement) {
+    const contextElements = [identityElement];
+    let current = identityElement.parentElement;
+    let depth = 0;
+
+    while (current && current !== postElement && depth < 3) {
+      const text = normalizeWhitespace(current.textContent || "");
+
+      if (text && text.length <= 240) {
+        contextElements.push(current);
+      }
+
+      current = current.parentElement;
+      depth += 1;
+    }
+
+    return getUniqueElements(contextElements);
+  }
+
+  function getElementSourceTexts(element) {
+    return [
+      ...new Set(
+        [
+          normalizeWhitespace(element?.textContent || ""),
+          normalizeWhitespace(element?.getAttribute?.("aria-label") || ""),
+        ].filter(Boolean)
+      ),
+    ];
+  }
+
+  function isIgnoredNetworkProximityLabel(text, author) {
+    const normalized = normalizeWhitespace(text || "");
+    const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+    if (!normalized) {
+      return true;
+    }
+
+    if (normalizedAuthor && normalized.toLowerCase().includes(normalizedAuthor)) {
+      return true;
+    }
+
+    if (normalized.length > 40 || normalized.split(/\s+/).length > 4) {
+      return true;
+    }
+
+    if (POSTED_TIME_PATTERN.test(normalized) || /^edited$/i.test(normalized)) {
+      return true;
+    }
+
+    if (
+      /^(open to work|hiring|executive top voice|top voice|verified profile|premium|profile)$/i.test(
+        normalized
+      )
+    ) {
+      return true;
+    }
+
+    return /^(likes this|loves this|supports this|found this insightful|reposted this|reposted|shared this|shared)$/i.test(
+      normalized
+    );
+  }
+
+  function extractFallbackNetworkProximity(postElement, author) {
+    const labels = new Set();
+
+    for (const identityElement of collectAuthorIdentityElements(postElement, author)) {
+      for (const contextElement of collectIdentityContextElements(postElement, identityElement)) {
+        const candidates = Array.from(contextElement.querySelectorAll("span, p, div, a"));
+
+        for (const candidate of candidates) {
+          for (const text of getElementSourceTexts(candidate)) {
+            if (isIgnoredNetworkProximityLabel(text, author)) {
+              continue;
+            }
+
+            labels.add(text);
+          }
+        }
+      }
+    }
+
+    return labels.size === 1 ? [...labels][0] : null;
+  }
+
+  function extractAuthorNetworkProximity(postElement, author) {
+    const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+    if (!normalizedAuthor) {
+      return null;
+    }
+
+    for (const identityElement of collectAuthorIdentityElements(postElement, author)) {
+      for (const contextElement of collectIdentityContextElements(postElement, identityElement)) {
+        for (const text of getElementSourceTexts(contextElement)) {
+          const marker = extractKnownRelationshipMarker(text);
+
+          if (marker) {
+            return marker;
+          }
+        }
+      }
+    }
+
+    return extractFallbackNetworkProximity(postElement, author);
+  }
+
   function extractLeadingSocialSignal(postElement, author) {
     const normalizedAuthor = normalizeWhitespace(author || "");
 
@@ -1290,6 +1457,7 @@ import {
       link: null,
       author: author,
       author_profile_url: extractAuthorProfileUrl(postElement, author),
+      author_network_proximity: extractAuthorNetworkProximity(postElement, author),
       reposted_by: repostMetadata.reposted_by,
       post_text: extractPostText(postElement),
       posted_time: extractPostedTime(postElement),

--- a/src/shared/export.js
+++ b/src/shared/export.js
@@ -3,6 +3,7 @@ function pickExportFields(item) {
     link: item?.link || null,
     author: item?.author || null,
     author_profile_url: item?.author_profile_url || null,
+    author_network_proximity: item?.author_network_proximity || null,
     reposted_by: item?.reposted_by || null,
     post_text: item?.post_text || null,
     posted_time: item?.posted_time || null,

--- a/src/shared/extractor.js
+++ b/src/shared/extractor.js
@@ -84,6 +84,28 @@ function hasRelationshipMarker(text) {
   return RELATIONSHIP_MARKERS.some((marker) => normalized.includes(marker));
 }
 
+function extractKnownRelationshipMarker(text) {
+  const normalized = normalizeWhitespace(text || "");
+
+  if (!normalized) {
+    return null;
+  }
+
+  for (const marker of RELATIONSHIP_MARKERS) {
+    const markerPattern = new RegExp(
+      `(?:^|[\\s\\u2022\\u00B7\\-])(${escapeRegExp(marker)})(?=\\s|$)`,
+      "i"
+    );
+    const match = normalized.match(markerPattern);
+
+    if (match?.[1]) {
+      return marker;
+    }
+  }
+
+  return null;
+}
+
 function normalizePersonKey(value) {
   return normalizeWhitespace(value || "").toLowerCase();
 }
@@ -300,6 +322,149 @@ export function extractAuthor(postElement, options = {}) {
   }
 
   return null;
+}
+
+function getUniqueElements(elements = []) {
+  const seen = new Set();
+  const uniqueElements = [];
+
+  for (const element of elements) {
+    if (!element || seen.has(element)) {
+      continue;
+    }
+
+    seen.add(element);
+    uniqueElements.push(element);
+  }
+
+  return uniqueElements;
+}
+
+function collectAuthorIdentityElements(postElement, author) {
+  const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+  if (!normalizedAuthor) {
+    return [];
+  }
+
+  return getUniqueElements(
+    Array.from(postElement.querySelectorAll('[aria-label], a[href*="/in/"], a[href*="/company/"]'))
+      .concat(Array.from(postElement.querySelectorAll("span, p, div")))
+      .filter((element) => {
+        const text = normalizeWhitespace(
+          [element.textContent || "", element.getAttribute?.("aria-label") || ""].join(" ")
+        ).toLowerCase();
+
+        return text.includes(normalizedAuthor);
+      })
+  );
+}
+
+function collectIdentityContextElements(postElement, identityElement) {
+  const contextElements = [identityElement];
+  let current = identityElement.parentElement;
+  let depth = 0;
+
+  while (current && current !== postElement && depth < 3) {
+    const text = normalizeWhitespace(current.textContent || "");
+
+    if (text && text.length <= 240) {
+      contextElements.push(current);
+    }
+
+    current = current.parentElement;
+    depth += 1;
+  }
+
+  return getUniqueElements(contextElements);
+}
+
+function getElementSourceTexts(element) {
+  return [
+    ...new Set(
+      [
+        normalizeWhitespace(element?.textContent || ""),
+        normalizeWhitespace(element?.getAttribute?.("aria-label") || ""),
+      ].filter(Boolean)
+    ),
+  ];
+}
+
+function isIgnoredNetworkProximityLabel(text, author) {
+  const normalized = normalizeWhitespace(text || "");
+  const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  if (normalizedAuthor && normalized.toLowerCase().includes(normalizedAuthor)) {
+    return true;
+  }
+
+  if (normalized.length > 40 || normalized.split(/\s+/).length > 4) {
+    return true;
+  }
+
+  if (POSTED_TIME_PATTERN.test(normalized) || /^edited$/i.test(normalized)) {
+    return true;
+  }
+
+  if (
+    /^(open to work|hiring|executive top voice|top voice|verified profile|premium|profile)$/i.test(
+      normalized
+    )
+  ) {
+    return true;
+  }
+
+  return /^(likes this|loves this|supports this|found this insightful|reposted this|reposted|shared this|shared)$/i.test(
+    normalized
+  );
+}
+
+function extractFallbackNetworkProximity(postElement, author) {
+  const labels = new Set();
+
+  for (const identityElement of collectAuthorIdentityElements(postElement, author)) {
+    for (const contextElement of collectIdentityContextElements(postElement, identityElement)) {
+      const candidates = Array.from(contextElement.querySelectorAll("span, p, div, a"));
+
+      for (const candidate of candidates) {
+        for (const text of getElementSourceTexts(candidate)) {
+          if (isIgnoredNetworkProximityLabel(text, author)) {
+            continue;
+          }
+
+          labels.add(text);
+        }
+      }
+    }
+  }
+
+  return labels.size === 1 ? [...labels][0] : null;
+}
+
+export function extractAuthorNetworkProximity(postElement, author, options = {}) {
+  const normalizedAuthor = normalizeWhitespace(author || "").toLowerCase();
+
+  if (!normalizedAuthor) {
+    return null;
+  }
+
+  for (const identityElement of collectAuthorIdentityElements(postElement, author)) {
+    for (const contextElement of collectIdentityContextElements(postElement, identityElement)) {
+      for (const text of getElementSourceTexts(contextElement)) {
+        const marker = extractKnownRelationshipMarker(text);
+
+        if (marker) {
+          return marker;
+        }
+      }
+    }
+  }
+
+  return extractFallbackNetworkProximity(postElement, author, options);
 }
 
 function extractLeadingSocialSignal(postElement, author) {
@@ -678,6 +843,7 @@ export function buildNormalizedItem(
     link: options.link || null,
     author,
     author_profile_url: extractAuthorProfileUrl(postElement, author),
+    author_network_proximity: extractAuthorNetworkProximity(postElement, author, options),
     reposted_by: repostMetadata.reposted_by,
     post_text: extractPostText(postElement),
     posted_time: extractPostedTime(postElement),

--- a/test/export.smoke.test.js
+++ b/test/export.smoke.test.js
@@ -12,6 +12,7 @@ describe("export helpers", () => {
       toRawExportItem({
         link: "https://example.com/post/1",
         author: "Ada Lovelace",
+        author_network_proximity: "1st",
         post_text: "Hello",
         posted_time: "4h",
         is_repost: false,
@@ -25,6 +26,7 @@ describe("export helpers", () => {
     ]);
 
     expect(json).toContain('"link": "https://example.com/post/1"');
+    expect(json).toContain('"author_network_proximity": "1st"');
     expect(json).toContain('"is_repost": false');
     expect(json).toContain('"comment_count": 12');
     expect(json).toContain('"reaction_count_text": "1.2K reactions"');
@@ -34,6 +36,7 @@ describe("export helpers", () => {
     const json = serializeExportItems([
       toEnrichedExportItem({
         author: "Ada Lovelace",
+        author_network_proximity: "Following",
         author_role: "Engineer",
         author_followers: 1200,
         author_weight: "high",
@@ -45,6 +48,7 @@ describe("export helpers", () => {
     ]);
 
     expect(json).toContain('"author_role": "Engineer"');
+    expect(json).toContain('"author_network_proximity": "Following"');
     expect(json).toContain('"author_followers": 1200');
     expect(json).toContain('"author_weight": "high"');
     expect(json).toContain('"comment_count": 3');
@@ -53,6 +57,7 @@ describe("export helpers", () => {
 
   it("serializes legacy engagement fields as null", () => {
     expect(toRawExportItem({ author: "Ada Lovelace" })).toMatchObject({
+      author_network_proximity: null,
       comment_count: null,
       comment_count_text: null,
       reaction_count: null,

--- a/test/extractor.smoke.test.js
+++ b/test/extractor.smoke.test.js
@@ -5,6 +5,7 @@ import {
   analyzePostElement,
   cleanPersonLabel,
   extractAuthor,
+  extractAuthorNetworkProximity,
   extractAuthorProfileUrl,
   extractPostEngagement,
   extractPostedTime,
@@ -156,6 +157,21 @@ const FEED_FIXTURE = `
         <p>15h •</p>
       </div>
       <span data-testid="expandable-text-box">Author should come from paragraph marker.</span>
+    </div>
+    <div role="listitem" data-post-id="future-proximity">
+      <div>
+        <a href="https://www.linkedin.com/in/sofia-chen/">Sofia Chen</a>
+        <span>Teammate</span>
+        <p>2h â€¢</p>
+      </div>
+      <span data-testid="expandable-text-box">Future proximity labels should be preserved.</span>
+    </div>
+    <div role="listitem" data-post-id="no-proximity">
+      <div>
+        <a href="https://www.linkedin.com/in/noah-kim/">Noah Kim</a>
+        <p>1d â€¢</p>
+      </div>
+      <span data-testid="expandable-text-box">No visible proximity signal here.</span>
     </div>
   </div>
   <div popover="manual">
@@ -318,7 +334,7 @@ describe("LinkedIn feed smoke extraction", () => {
     const container = findFeedContainer(document);
 
     expect(container).not.toBeNull();
-    expect(findPostElements(container)).toHaveLength(12);
+    expect(findPostElements(container)).toHaveLength(14);
   });
 
   it("filters promoted content", () => {
@@ -355,6 +371,20 @@ describe("LinkedIn feed smoke extraction", () => {
     expect(extractAuthor(posts[8])).toBe("Liz Fong-Jones");
     expect(extractAuthor(posts[10])).toBe("Patty Fonacier");
     expect(extractAuthor(posts[11])).toBe("Muhammad Haseeb");
+    expect(extractAuthor(posts[12])).toBe("Sofia Chen");
+    expect(extractAuthor(posts[13])).toBe("Noah Kim");
+  });
+
+  it("extracts author network proximity and preserves future labels", () => {
+    const document = setupDocument();
+    const posts = findPostElements(findFeedContainer(document));
+
+    expect(extractAuthorNetworkProximity(posts[0], extractAuthor(posts[0]))).toBe("1st");
+    expect(extractAuthorNetworkProximity(posts[2], extractAuthor(posts[2]))).toBe("3rd+");
+    expect(extractAuthorNetworkProximity(posts[4], extractAuthor(posts[4]))).toBe("Following");
+    expect(extractAuthorNetworkProximity(posts[5], "Liz Fong-Jones")).toBe("3rd+");
+    expect(extractAuthorNetworkProximity(posts[12], extractAuthor(posts[12]))).toBe("Teammate");
+    expect(extractAuthorNetworkProximity(posts[13], extractAuthor(posts[13]))).toBeNull();
   });
 
   it("cleans author labels polluted by LinkedIn badges and timestamps", () => {
@@ -462,12 +492,13 @@ describe("LinkedIn feed smoke extraction", () => {
     });
     const secondPass = scanFeedPosts(container, { processedElements });
 
-    expect(firstPass.acceptedItems).toHaveLength(10);
+    expect(firstPass.acceptedItems).toHaveLength(12);
     expect(firstPass.skippedItems).toContain("promoted");
     expect(firstPass.skippedItems).toContain("missing-author");
     expect(firstPass.acceptedItems[0]).toMatchObject({
       author: "Gonzalo Corbijn",
       author_profile_url: "https://www.linkedin.com/in/gonzalo-corbijn/",
+      author_network_proximity: "1st",
       author_role: null,
       author_followers: null,
       author_weight: "low",
@@ -480,6 +511,7 @@ describe("LinkedIn feed smoke extraction", () => {
     });
     expect(firstPass.acceptedItems.find((item) => item.author === "Liz Fong-Jones")).toMatchObject({
       author: "Liz Fong-Jones",
+      author_network_proximity: "3rd+",
       is_repost: true,
       reposted_by: "Charity Majors",
     });
@@ -487,15 +519,18 @@ describe("LinkedIn feed smoke extraction", () => {
       firstPass.acceptedItems.find((item) => item.post_text === "Should be skipped as suggested.")
     ).toMatchObject({
       author: "Muhammad Haseeb",
+      author_network_proximity: "3rd+",
       post_text: "Should be skipped as suggested.",
     });
     expect(firstPass.acceptedItems.find((item) => item.author === "Cruz Gamboa")).toMatchObject({
       author: "Cruz Gamboa",
+      author_network_proximity: "3rd+",
       is_repost: false,
       reposted_by: null,
     });
     expect(firstPass.acceptedItems.find((item) => item.author === "Maarten Dalmijn")).toMatchObject(
       {
+        author_network_proximity: "2nd",
         is_repost: false,
         reposted_by: null,
       }
@@ -511,11 +546,13 @@ describe("LinkedIn feed smoke extraction", () => {
       )
     ).toMatchObject({
       author: "Liz Fong-Jones",
+      author_network_proximity: "3rd+",
       is_repost: true,
       reposted_by: "Rob Sandberg",
     });
     expect(firstPass.acceptedItems.find((item) => item.author === "Patty Fonacier")).toMatchObject({
       author: "Patty Fonacier",
+      author_network_proximity: "1st",
       post_text: "Author should come from aria-label.",
     });
     expect(
@@ -524,6 +561,21 @@ describe("LinkedIn feed smoke extraction", () => {
       )
     ).toMatchObject({
       author: "Muhammad Haseeb",
+      author_network_proximity: "3rd+",
+    });
+    expect(
+      firstPass.acceptedItems.find(
+        (item) => item.post_text === "Future proximity labels should be preserved."
+      )
+    ).toMatchObject({
+      author: "Sofia Chen",
+      author_network_proximity: "Teammate",
+    });
+    expect(
+      firstPass.acceptedItems.find((item) => item.post_text === "No visible proximity signal here.")
+    ).toMatchObject({
+      author: "Noah Kim",
+      author_network_proximity: null,
     });
     expect(secondPass.acceptedItems).toHaveLength(0);
   });
@@ -539,10 +591,10 @@ describe("LinkedIn feed smoke extraction", () => {
     const firstMerge = mergeNewItems(101, acceptedItems);
     const secondMerge = mergeNewItems(101, acceptedItems);
 
-    expect(firstMerge.addedCount).toBe(10);
+    expect(firstMerge.addedCount).toBe(12);
     expect(secondMerge.addedCount).toBe(0);
     expect(getSerializableState(101).aiCounts).toEqual({
-      pending: 10,
+      pending: 12,
       interested: 0,
       not_interested: 0,
       unknown: 0,

--- a/test/state.smoke.test.js
+++ b/test/state.smoke.test.js
@@ -3,6 +3,7 @@ import {
   appendIgnoredSamples,
   getAiValidationEligibleItems,
   getLatestResultItems,
+  mergeNewItems,
   getSerializableState,
   hydrateStateFromStorage,
   resetAiValidationStatuses,
@@ -272,6 +273,27 @@ describe("tab state debug samples", () => {
     });
   });
 
+  it("preserves author_network_proximity through merge and snapshots", async () => {
+    mockChromeStorage();
+
+    const mergeResult = mergeNewItems(57, [
+      {
+        fingerprint: "fp-proximity",
+        author: "Ada",
+        extracted_at: "2026-03-30T10:00:00.000Z",
+        author_network_proximity: "1st",
+      },
+    ]);
+
+    expect(mergeResult.addedCount).toBe(1);
+    expect(mergeResult.state.items[0]).toMatchObject({
+      author_network_proximity: "1st",
+    });
+    expect(getLatestResultItems(57).items[0]).toMatchObject({
+      author_network_proximity: "1st",
+    });
+  });
+
   it("counts unresolved separately and excludes it from classified progress", async () => {
     mockChromeStorage();
 
@@ -334,6 +356,7 @@ describe("tab state debug samples", () => {
             author: "Ada",
             extracted_at: "2026-03-30T10:00:00.000Z",
             author_profile_url: "https://www.linkedin.com/in/ada/",
+            author_network_proximity: "2nd",
             interest_validation: {
               status: "interested",
               attempts: 1,
@@ -360,6 +383,7 @@ describe("tab state debug samples", () => {
           author: "Ada",
           extracted_at: "2026-03-30T10:00:00.000Z",
           author_profile_url: "https://www.linkedin.com/in/ada/",
+          author_network_proximity: "2nd",
           author_role: "Engineer",
           author_followers: 1200,
           author_weight: "low",
@@ -379,6 +403,7 @@ describe("tab state debug samples", () => {
     expect(latest.mode).toBe("enriched");
     expect(latest.items).toHaveLength(1);
     expect(latest.items[0]).toMatchObject({
+      author_network_proximity: "2nd",
       author_role: "Engineer",
       author_followers: 1200,
       author_weight: "low",


### PR DESCRIPTION
## Summary
- add author_network_proximity to the normalized post contract and JSON exports
- extract proximity from the final resolved author block, including repost handling and fallback labels
- cover the new contract in extractor, export, state, and docs updates

## Verification
- npm run prepush

Closes #39
